### PR TITLE
Fix exception in Special:Search for no results (false/null)

### DIFF
--- a/src/Search/LanguageResultMatchFinder.php
+++ b/src/Search/LanguageResultMatchFinder.php
@@ -35,7 +35,7 @@ class LanguageResultMatchFinder {
 	 * @param SearchResultSet $matches
 	 * @param $languageCode
 	 *
-	 * @return MappedSearchResultSet|boolean
+	 * @return MappedSearchResultSet|null
 	 */
 	public function matchResultsToLanguage( SearchResultSet $matches, $languageCode ) {
 
@@ -53,7 +53,7 @@ class LanguageResultMatchFinder {
 		}
 
 		if ( $mappedMatches === array() ) {
-			return false;
+			return null;
 		}
 
 		return new MappedSearchResultSet( $mappedMatches, $matches->termMatches() );

--- a/tests/phpunit/Unit/Search/LanguageResultMatchFinderTest.php
+++ b/tests/phpunit/Unit/Search/LanguageResultMatchFinderTest.php
@@ -42,7 +42,7 @@ class LanguageResultMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->assertFalse(
+		$this->assertNull(
 			$instance->matchResultsToLanguage( $searchResultSet, 'en' )
 		);
 	}
@@ -71,7 +71,7 @@ class LanguageResultMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'next' )
 			->will( $this->onConsecutiveCalls( $searchresult, false ) );
 
-		$this->assertFalse(
+		$this->assertNull(
 			$instance->matchResultsToLanguage( $searchResultSet, 'en' )
 		);
 	}


### PR DESCRIPTION
Call to a member function searchContainedSyntax() on a non-object in
...\specials\SpecialSearch.php on line 419

false vs null