### PR TITLE
Add PageContentLanguageModifier::addToIntermediaryCache

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 This file contains the RELEASE-NOTES of the Semantic Interlanguage Links (a.k.a. SIL) extension.
 
+### 1.3.0 (undefined)
+
+* #38 Added access to `PageContentLanguageModifier` in `InterlanguageLinkParserFunction` allowing
+  the language code to be temporarily available while the content is still being process
+  (important when `DataValueFactory` seeks access to a subject)
+* #37 Added check whether `LanguageLinkAnnotator` can actually add annotations
+* #35 Added `InMemoryLruCache` to `PageContentLanguageModifier`
 * #33 Fixed language code in `Special:Search` to conform with IETF (ISO 639, BCP 47) norm
 
 ### 1.2.0 (2015-12-19)

--- a/SemanticInterlanguageLinks.php
+++ b/SemanticInterlanguageLinks.php
@@ -23,7 +23,7 @@ if ( defined( 'SIL_VERSION' ) ) {
 	return 1;
 }
 
-define( 'SIL_VERSION', '1.2.0-alpha' );
+define( 'SIL_VERSION', '1.3.0-alpha' );
 
 /**
  * @codeCoverageIgnore

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -119,12 +119,13 @@ class HookRegistry {
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ParserFirstCallInit
 		 */
-		$this->handlers['ParserFirstCallInit'] = function ( &$parser ) use( $interlanguageLinksLookup ) {
+		$this->handlers['ParserFirstCallInit'] = function ( &$parser ) use( $interlanguageLinksLookup, $pageContentLanguageModifier ) {
 
 			$parserFunctionFactory = new ParserFunctionFactory();
 
 			list( $name, $definition, $flag ) = $parserFunctionFactory->newInterlanguageLinkParserFunctionDefinition(
-				$interlanguageLinksLookup
+				$interlanguageLinksLookup,
+				$pageContentLanguageModifier
 			);
 
 			$parser->setFunctionHook( $name, $definition, $flag );

--- a/src/LanguageLinkAnnotator.php
+++ b/src/LanguageLinkAnnotator.php
@@ -51,7 +51,7 @@ class LanguageLinkAnnotator {
 	}
 
 	/**
-	 * @since 1.2
+	 * @since 1.3
 	 *
 	 * @return boolean
 	 */

--- a/src/PageContentLanguageModifier.php
+++ b/src/PageContentLanguageModifier.php
@@ -44,6 +44,16 @@ class PageContentLanguageModifier {
 	}
 
 	/**
+	 * @since 1.3
+	 *
+	 * @param Title $title
+	 * @param string &languageCode
+	 */
+	public function addToIntermediaryCache( Title $title, $languageCode ) {
+		$this->intermediaryCache->save( $this->getHashFrom( $title ), $languageCode );
+	}
+
+	/**
 	 * @since 1.0
 	 *
 	 * @param Title $title
@@ -53,7 +63,7 @@ class PageContentLanguageModifier {
 	 */
 	public function getPageContentLanguage( Title $title, $pageLanguage ) {
 
-		$hash = md5( $title->getPrefixedText() );
+		$hash = $this->getHashFrom( $title );
 
 		if ( ( $cachedLanguageCode = $this->intermediaryCache->fetch( $hash ) ) ) {
 			return $cachedLanguageCode;
@@ -72,6 +82,10 @@ class PageContentLanguageModifier {
 		$this->intermediaryCache->save( $hash, $pageLanguage );
 
 		return $pageLanguage;
+	}
+
+	private function getHashFrom( Title $title ) {
+		return md5( $title->getPrefixedText() );
 	}
 
 }

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -17,12 +17,13 @@ class ParserFunctionFactory {
 	 * @since  1.0
 	 *
 	 * @param InterlanguageLinksLookup $interlanguageLinksLookup
+	 * @param PageContentLanguageModifier $pageContentLanguageModifier
 	 *
 	 * @return array
 	 */
-	public function newInterlanguageLinkParserFunctionDefinition( InterlanguageLinksLookup $interlanguageLinksLookup ) {
+	public function newInterlanguageLinkParserFunctionDefinition( InterlanguageLinksLookup $interlanguageLinksLookup, PageContentLanguageModifier $pageContentLanguageModifier ) {
 
-		$interlanguageLinkParserFunctionDefinition = function( $parser, $languageCode, $linkReference = '' ) use ( $interlanguageLinksLookup ) {
+		$interlanguageLinkParserFunctionDefinition = function( $parser, $languageCode, $linkReference = '' ) use ( $interlanguageLinksLookup, $pageContentLanguageModifier ) {
 
 			$parserData = ApplicationFactory::getInstance()->newParserData(
 				$parser->getTitle(),
@@ -39,7 +40,8 @@ class ParserFunctionFactory {
 			$interlanguageLinkParserFunction = new InterlanguageLinkParserFunction(
 				$parser->getTitle(),
 				$languageLinkAnnotator,
-				$siteLanguageLinksParserOutputAppender
+				$siteLanguageLinksParserOutputAppender,
+				$pageContentLanguageModifier
 			);
 
 			$interlanguageLinkParserFunction->setRevisionModeState(

--- a/tests/phpunit/Unit/InterlanguageLinkParserFunctionTest.php
+++ b/tests/phpunit/Unit/InterlanguageLinkParserFunctionTest.php
@@ -17,6 +17,7 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 	private $languageLinkAnnotator;
 	private $siteLanguageLinksParserOutputAppender;
+	private $pageContentLanguageModifier;
 
 	protected function setUp() {
 		parent::setUp();
@@ -32,6 +33,10 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$this->siteLanguageLinksParserOutputAppender = $this->getMockBuilder( '\SIL\SiteLanguageLinksParserOutputAppender' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->pageContentLanguageModifier = $this->getMockBuilder( '\SIL\PageContentLanguageModifier' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	public function testCanConstruct() {
@@ -45,7 +50,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			new InterlanguageLinkParserFunction(
 				$title,
 				$this->languageLinkAnnotator,
-				$this->siteLanguageLinksParserOutputAppender
+				$this->siteLanguageLinksParserOutputAppender,
+				$this->pageContentLanguageModifier
 			)
 		);
 	}
@@ -59,7 +65,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance = new InterlanguageLinkParserFunction(
 			$title,
 			$this->languageLinkAnnotator,
-			$this->siteLanguageLinksParserOutputAppender
+			$this->siteLanguageLinksParserOutputAppender,
+			$this->pageContentLanguageModifier
 		);
 
 		$instance->setInterlanguageLinksHideState( true );
@@ -109,7 +116,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance = new InterlanguageLinkParserFunction(
 			$title,
 			$this->languageLinkAnnotator,
-			$this->siteLanguageLinksParserOutputAppender
+			$this->siteLanguageLinksParserOutputAppender,
+			$this->pageContentLanguageModifier
 		);
 
 		$instance->setInterlanguageLinksHideState( false );
@@ -131,7 +139,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance = new InterlanguageLinkParserFunction(
 			$title,
 			$this->languageLinkAnnotator,
-			$this->siteLanguageLinksParserOutputAppender
+			$this->siteLanguageLinksParserOutputAppender,
+			$this->pageContentLanguageModifier
 		);
 
 		$this->assertContains(
@@ -160,7 +169,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance = new InterlanguageLinkParserFunction(
 			$title,
 			$this->languageLinkAnnotator,
-			$this->siteLanguageLinksParserOutputAppender
+			$this->siteLanguageLinksParserOutputAppender,
+			$this->pageContentLanguageModifier
 		);
 
 		$instance->parse( 'en', 'Foo' );
@@ -187,7 +197,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance = new InterlanguageLinkParserFunction(
 			$title,
 			$this->languageLinkAnnotator,
-			$this->siteLanguageLinksParserOutputAppender
+			$this->siteLanguageLinksParserOutputAppender,
+			$this->pageContentLanguageModifier
 		);
 
 		$instance->setInterlanguageLinksHideState( false );
@@ -211,7 +222,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance = new InterlanguageLinkParserFunction(
 			$title,
 			$this->languageLinkAnnotator,
-			$this->siteLanguageLinksParserOutputAppender
+			$this->siteLanguageLinksParserOutputAppender,
+			$this->pageContentLanguageModifier
 		);
 
 		$instance->setRevisionModeState( true );
@@ -238,12 +250,37 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance = new InterlanguageLinkParserFunction(
 			$title,
 			$languageLinkAnnotator,
-			$this->siteLanguageLinksParserOutputAppender
+			$this->siteLanguageLinksParserOutputAppender,
+			$this->pageContentLanguageModifier
 		);
 
 		$this->assertEmpty(
 			$instance->parse( 'en', 'Foo' )
 		);
+	}
+
+	public function testAddLanguageCodeToPageContentLanguageIntermediaryCache() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$languageLinkAnnotator = $this->getMockBuilder( '\SIL\LanguageLinkAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->pageContentLanguageModifier->expects( $this->once() )
+			->method( 'addToIntermediaryCache' );
+
+		$instance = new InterlanguageLinkParserFunction(
+			$title,
+			$languageLinkAnnotator,
+			$this->siteLanguageLinksParserOutputAppender,
+			$this->pageContentLanguageModifier
+		);
+
+		$instance->setRevisionModeState( true );
+		$instance->parse( 'en', 'Foo' );
 	}
 
 }

--- a/tests/phpunit/Unit/PageContentLanguageModifierTest.php
+++ b/tests/phpunit/Unit/PageContentLanguageModifierTest.php
@@ -162,6 +162,38 @@ class PageContentLanguageModifierTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testAddToIntermediaryCache() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getPrefixedText' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->anything(),
+				$this->equalTo( 'BAR' ) );
+
+		$interlanguageLinksLookup = $this->getMockBuilder( '\SIL\InterlanguageLinksLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PageContentLanguageModifier(
+			$interlanguageLinksLookup,
+			$cache
+		);
+
+		$instance->addToIntermediaryCache( $title, 'BAR' );
+	}
+
 	public function invalidLanguageCodeProvider() {
 
 		$provider = array(

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -42,12 +42,17 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$pageContentLanguageModifier = $this->getMockBuilder( '\SIL\PageContentLanguageModifier' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->parser->setTitle( Title::newFromText( __METHOD__ ) );
 
 		$instance = new ParserFunctionFactory();
 
 		list( $name, $definition, $flag ) = $instance->newInterlanguageLinkParserFunctionDefinition(
-			$interlanguageLinksLookup
+			$interlanguageLinksLookup,
+			$pageContentLanguageModifier
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
Allowing the `InterlanguageLinkParserFunction` to set the language code early so that the `DataValueFactory` can have access to it while the parser is still processing the page.