### PR TITLE
Add PageContentLanguageDbModifier to handle wgPageLanguageUseDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ together with some [#ask queries](https://github.com/SemanticMediaWiki/SemanticI
    during each page view with cache invalidation being carried out during any delete, change or move action.
 - `$GLOBALS['wgHideInterlanguageLinks']` is enabled (set to `true`), no sitelinks or annotations are created
   (in order to correspond to the MW default behaviour for interwiki links)
+- If `$GLOBALS['wgPageLanguageUseDB']` was enabled and `Special:PageLanguage` assigned a different language from
+  the annotated SIL value then the `Page content language` will be restored to provide consistency with the
+  expected language
 
 ## Contribution and support
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,11 +2,13 @@ This file contains the RELEASE-NOTES of the Semantic Interlanguage Links (a.k.a.
 
 ### 1.3.0 (undefined)
 
-* #38 Added access to `PageContentLanguageModifier` in `InterlanguageLinkParserFunction` allowing
+* Added `PageContentLanguageDbModifier` to handle possible deviations caused by an
+  enabled `wgPageLanguageUseDB` setting
+* #38 Added access to `PageContentLanguageOnTheFlyModifier` in `InterlanguageLinkParserFunction` allowing
   the language code to be temporarily available while the content is still being process
   (important when `DataValueFactory` seeks access to a subject)
 * #37 Added check whether `LanguageLinkAnnotator` can actually add annotations
-* #35 Added `InMemoryLruCache` to `PageContentLanguageModifier`
+* #35 Added `InMemoryLruCache` to `PageContentLanguageOnTheFlyModifier`
 * #33 Fixed language code in `Special:Search` to conform with IETF (ISO 639, BCP 47) norm
 
 ### 1.2.0 (2015-12-19)

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -111,21 +111,21 @@ class HookRegistry {
 
 	private function registerInterlanguageParserHooks( InterlanguageLinksLookup $interlanguageLinksLookup ) {
 
-		$pageContentLanguageModifier = new PageContentLanguageModifier(
+		$pageContentLanguageOnTheFlyModifier = new PageContentLanguageOnTheFlyModifier(
 			$interlanguageLinksLookup,
-			InMemoryPoolCache::getInstance()->getPoolCacheFor( PageContentLanguageModifier::POOLCACHE_ID )
+			InMemoryPoolCache::getInstance()->getPoolCacheFor( PageContentLanguageOnTheFlyModifier::POOLCACHE_ID )
 		);
 
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ParserFirstCallInit
 		 */
-		$this->handlers['ParserFirstCallInit'] = function ( &$parser ) use( $interlanguageLinksLookup, $pageContentLanguageModifier ) {
+		$this->handlers['ParserFirstCallInit'] = function ( &$parser ) use( $interlanguageLinksLookup, $pageContentLanguageOnTheFlyModifier ) {
 
 			$parserFunctionFactory = new ParserFunctionFactory();
 
 			list( $name, $definition, $flag ) = $parserFunctionFactory->newInterlanguageLinkParserFunctionDefinition(
 				$interlanguageLinksLookup,
-				$pageContentLanguageModifier
+				$pageContentLanguageOnTheFlyModifier
 			);
 
 			$parser->setFunctionHook( $name, $definition, $flag );
@@ -205,9 +205,9 @@ class HookRegistry {
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/PageContentLanguage
 		 */
-		$this->handlers['PageContentLanguage'] = function ( $title, &$pageLang ) use ( $pageContentLanguageModifier ) {
+		$this->handlers['PageContentLanguage'] = function ( $title, &$pageLang ) use ( $pageContentLanguageOnTheFlyModifier ) {
 
-			$pageLang = $pageContentLanguageModifier->getPageContentLanguage(
+			$pageLang = $pageContentLanguageOnTheFlyModifier->getPageContentLanguage(
 				$title,
 				$pageLang
 			);

--- a/src/PageContentLanguageDbModifier.php
+++ b/src/PageContentLanguageDbModifier.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace SIL;
+
+use LinkCache;
+use Title;
+use DatabaseBase;
+
+/**
+ * Handling Title::getDbPageLanguageCode and Special:PageLanguage to avoid possible
+ * contradictory results when $wgPageLanguageUseDB is enabled.
+ *
+ * If wgPageLanguageUseDB is enabled then the PageContentLanguage hook is not
+ * going to be called in case Special:PageLanguage assigned a pagelanguage which
+ * could create a possible deviation between SIL annotation and the stored DB
+ * `page_lang`.
+ *
+ * @license GNU GPL v2+
+ * @since 1.3
+ *
+ * @author mwjames
+ */
+class PageContentLanguageDbModifier {
+
+	/**
+	 * @var Title
+	 */
+	private $title;
+
+	/**
+	 * @var DatabaseBase
+	 */
+	private $connection;
+
+	/**
+	 * @var LinkCache
+	 */
+	private $linkCache;
+
+	/**
+	 * @var boolean
+	 */
+	private $isDbPageLanguage = false;
+
+	/**
+	 * @var string|false
+	 */
+	private $dbPageLanguage = false;
+
+	/**
+	 * @since 1.3
+	 *
+	 * @param Title $title
+	 * @param DatabaseBase|null $connection
+	 * @param LinkCache|null $linkCache
+	 */
+	public function __construct( Title $title, DatabaseBase $connection = null, LinkCache $linkCache = null ) {
+		$this->title = $title;
+		$this->connection = $connection;
+		$this->linkCache = $linkCache;
+	}
+
+	/**
+	 * @since 1.3
+	 *
+	 * @param boolean $isDbPageLanguage
+	 */
+	public function markAsPageLanguageByDB( $isDbPageLanguage ) {
+		$this->isDbPageLanguage = $isDbPageLanguage;
+	}
+
+	/**
+	 * @since 1.3
+	 *
+	 * @param string $expectedLanguageCode
+	 */
+	public function updatePageLanguage( $expectedLanguageCode ) {
+
+		if ( !$this->isDbPageLanguage ) {
+			return null;
+		}
+
+		$expectedLanguageCode = strtolower( $expectedLanguageCode );
+
+		// If the pagelanguage added via Special:PageLanguage is different from
+		// what SIL is expecting then push for a DB update
+		if ( $this->getDbPageLanguageCode() && $this->dbPageLanguage !== $expectedLanguageCode ) {
+			$this->doUpdate( $expectedLanguageCode, $this->dbPageLanguage );
+		}
+	}
+
+	// @see Title::getDbPageLanguageCode
+	private function getDbPageLanguageCode() {
+
+		if ( $this->linkCache === null ) {
+			$this->linkCache = LinkCache::singleton();
+		}
+
+		// check, if the page language could be saved in the database, and if so and
+		// the value is not requested already, lookup the page language using LinkCache
+		if ( $this->isDbPageLanguage && $this->dbPageLanguage === false ) {
+			$this->linkCache->addLinkObj( $this->title );
+			$this->dbPageLanguage = $this->linkCache->getGoodLinkFieldObj( $this->title, 'lang' );
+		}
+
+		return $this->dbPageLanguage;
+	}
+
+	// @see Special:PageLanguage::onSubmit
+	private function doUpdate( $expectedLanguageCode, $dbPageLanguage ) {
+
+		$connection = $this->connection;
+		$title = $this->title;
+
+		if ( $connection === null ) {
+			 $connection = wfGetDB( DB_MASTER );
+		}
+
+		$connection->onTransactionIdle( function() use ( $connection, $expectedLanguageCode, $dbPageLanguage, $title ) {
+
+			$pageId = $title->getArticleID();
+
+			$connection->update(
+				'page',
+				array(
+					'page_lang' => $expectedLanguageCode
+				),
+				array(
+					'page_id'   => $pageId,
+					'page_lang' => $dbPageLanguage
+				),
+				__METHOD__
+			);
+		} );
+	}
+
+}

--- a/src/PageContentLanguageOnTheFlyModifier.php
+++ b/src/PageContentLanguageOnTheFlyModifier.php
@@ -18,7 +18,7 @@ use Title;
  *
  * @author mwjames
  */
-class PageContentLanguageModifier {
+class PageContentLanguageOnTheFlyModifier {
 
 	const POOLCACHE_ID = 'sil.pagecontentlanguage';
 

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -17,13 +17,22 @@ class ParserFunctionFactory {
 	 * @since  1.0
 	 *
 	 * @param InterlanguageLinksLookup $interlanguageLinksLookup
-	 * @param PageContentLanguageModifier $pageContentLanguageModifier
+	 * @param PageContentLanguageOnTheFlyModifier $pageContentLanguageOnTheFlyModifier
 	 *
 	 * @return array
 	 */
-	public function newInterlanguageLinkParserFunctionDefinition( InterlanguageLinksLookup $interlanguageLinksLookup, PageContentLanguageModifier $pageContentLanguageModifier ) {
+	public function newInterlanguageLinkParserFunctionDefinition( InterlanguageLinksLookup $interlanguageLinksLookup, PageContentLanguageOnTheFlyModifier $pageContentLanguageOnTheFlyModifier ) {
 
-		$interlanguageLinkParserFunctionDefinition = function( $parser, $languageCode, $linkReference = '' ) use ( $interlanguageLinksLookup, $pageContentLanguageModifier ) {
+		$interlanguageLinkParserFunctionDefinition = function( $parser, $languageCode, $linkReference = '' ) use ( $interlanguageLinksLookup, $pageContentLanguageOnTheFlyModifier ) {
+
+			$pageContentLanguageDbModifier = new PageContentLanguageDbModifier(
+				$parser->getTitle()
+			);
+
+			// MW 1.24+
+			$pageContentLanguageDbModifier->markAsPageLanguageByDB(
+				isset( $GLOBALS['wgPageLanguageUseDB'] ) ? $GLOBALS['wgPageLanguageUseDB'] : false
+			);
 
 			$parserData = ApplicationFactory::getInstance()->newParserData(
 				$parser->getTitle(),
@@ -41,7 +50,8 @@ class ParserFunctionFactory {
 				$parser->getTitle(),
 				$languageLinkAnnotator,
 				$siteLanguageLinksParserOutputAppender,
-				$pageContentLanguageModifier
+				$pageContentLanguageOnTheFlyModifier,
+				$pageContentLanguageDbModifier
 			);
 
 			$interlanguageLinkParserFunction->setRevisionModeState(

--- a/tests/phpunit/Unit/InterlanguageLinkParserFunctionTest.php
+++ b/tests/phpunit/Unit/InterlanguageLinkParserFunctionTest.php
@@ -17,7 +17,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 	private $languageLinkAnnotator;
 	private $siteLanguageLinksParserOutputAppender;
-	private $pageContentLanguageModifier;
+	private $pageContentLanguageOnTheFlyModifier;
+	private $pageContentLanguageDbModifier;
 
 	protected function setUp() {
 		parent::setUp();
@@ -34,7 +35,11 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->pageContentLanguageModifier = $this->getMockBuilder( '\SIL\PageContentLanguageModifier' )
+		$this->pageContentLanguageOnTheFlyModifier = $this->getMockBuilder( '\SIL\PageContentLanguageOnTheFlyModifier' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->pageContentLanguageDbModifier = $this->getMockBuilder( '\SIL\PageContentLanguageDbModifier' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -51,7 +56,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				$title,
 				$this->languageLinkAnnotator,
 				$this->siteLanguageLinksParserOutputAppender,
-				$this->pageContentLanguageModifier
+				$this->pageContentLanguageOnTheFlyModifier,
+				$this->pageContentLanguageDbModifier
 			)
 		);
 	}
@@ -66,7 +72,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			$title,
 			$this->languageLinkAnnotator,
 			$this->siteLanguageLinksParserOutputAppender,
-			$this->pageContentLanguageModifier
+			$this->pageContentLanguageOnTheFlyModifier,
+			$this->pageContentLanguageDbModifier
 		);
 
 		$instance->setInterlanguageLinksHideState( true );
@@ -117,7 +124,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			$title,
 			$this->languageLinkAnnotator,
 			$this->siteLanguageLinksParserOutputAppender,
-			$this->pageContentLanguageModifier
+			$this->pageContentLanguageOnTheFlyModifier,
+			$this->pageContentLanguageDbModifier
 		);
 
 		$instance->setInterlanguageLinksHideState( false );
@@ -140,7 +148,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			$title,
 			$this->languageLinkAnnotator,
 			$this->siteLanguageLinksParserOutputAppender,
-			$this->pageContentLanguageModifier
+			$this->pageContentLanguageOnTheFlyModifier,
+			$this->pageContentLanguageDbModifier
 		);
 
 		$this->assertContains(
@@ -170,7 +179,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			$title,
 			$this->languageLinkAnnotator,
 			$this->siteLanguageLinksParserOutputAppender,
-			$this->pageContentLanguageModifier
+			$this->pageContentLanguageOnTheFlyModifier,
+			$this->pageContentLanguageDbModifier
 		);
 
 		$instance->parse( 'en', 'Foo' );
@@ -198,7 +208,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			$title,
 			$this->languageLinkAnnotator,
 			$this->siteLanguageLinksParserOutputAppender,
-			$this->pageContentLanguageModifier
+			$this->pageContentLanguageOnTheFlyModifier,
+			$this->pageContentLanguageDbModifier
 		);
 
 		$instance->setInterlanguageLinksHideState( false );
@@ -223,7 +234,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			$title,
 			$this->languageLinkAnnotator,
 			$this->siteLanguageLinksParserOutputAppender,
-			$this->pageContentLanguageModifier
+			$this->pageContentLanguageOnTheFlyModifier,
+			$this->pageContentLanguageDbModifier
 		);
 
 		$instance->setRevisionModeState( true );
@@ -251,7 +263,8 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			$title,
 			$languageLinkAnnotator,
 			$this->siteLanguageLinksParserOutputAppender,
-			$this->pageContentLanguageModifier
+			$this->pageContentLanguageOnTheFlyModifier,
+			$this->pageContentLanguageDbModifier
 		);
 
 		$this->assertEmpty(
@@ -269,14 +282,15 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->pageContentLanguageModifier->expects( $this->once() )
+		$this->pageContentLanguageOnTheFlyModifier->expects( $this->once() )
 			->method( 'addToIntermediaryCache' );
 
 		$instance = new InterlanguageLinkParserFunction(
 			$title,
 			$languageLinkAnnotator,
 			$this->siteLanguageLinksParserOutputAppender,
-			$this->pageContentLanguageModifier
+			$this->pageContentLanguageOnTheFlyModifier,
+			$this->pageContentLanguageDbModifier
 		);
 
 		$instance->setRevisionModeState( true );

--- a/tests/phpunit/Unit/PageContentLanguageDbModifierTest.php
+++ b/tests/phpunit/Unit/PageContentLanguageDbModifierTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SIL\Tests;
+
+use SIL\PageContentLanguageDbModifier;
+use Title;
+
+/**
+ * @covers \SIL\PageContentLanguageDbModifier
+ * @group semantic-interlanguage-links
+ *
+ * @license GNU GPL v2+
+ * @since 1.3
+ *
+ * @author mwjames
+ */
+class PageContentLanguageDbModifierTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SIL\PageContentLanguageDbModifier',
+			new PageContentLanguageDbModifier( $title )
+		);
+	}
+
+	public function testNotMarkedAsPageLanguageByDB() {
+
+		$title = Title::newFromText( __METHOD__ );
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new PageContentLanguageDbModifier(
+			$title,
+			$connection
+		);
+
+		$instance->markAsPageLanguageByDB( false );
+
+		$this->assertNull(
+			$instance->updatePageLanguage( 'en' )
+		);
+	}
+
+	public function testForceUpdateOfPageLanguageOnDifferentLanguageCode() {
+
+		$title = Title::newFromText( __METHOD__ );
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'update' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->once() )
+			->method( 'update' );
+
+		$linkCache = $this->getMockBuilder( '\LinkCache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$linkCache->expects( $this->once() )
+			->method( 'getGoodLinkFieldObj' )
+			->will( $this->returnValue(  'fr' ) );
+
+		$instance = new PageContentLanguageDbModifier(
+			$title,
+			$connection,
+			$linkCache
+		);
+
+		$instance->markAsPageLanguageByDB( true );
+		$instance->updatePageLanguage( 'en' );
+	}
+
+	public function testNoUpdateOnSameLanguageCode() {
+
+		$title = Title::newFromText( __METHOD__ );
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'update' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->never() )
+			->method( 'update' );
+
+		$linkCache = $this->getMockBuilder( '\LinkCache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$linkCache->expects( $this->once() )
+			->method( 'getGoodLinkFieldObj' )
+			->will( $this->returnValue(  'en' ) );
+
+		$instance = new PageContentLanguageDbModifier(
+			$title,
+			$connection,
+			$linkCache
+		);
+
+		$instance->markAsPageLanguageByDB( true );
+		$instance->updatePageLanguage( 'en' );
+	}
+
+}

--- a/tests/phpunit/Unit/PageContentLanguageOnTheFlyModifierTest.php
+++ b/tests/phpunit/Unit/PageContentLanguageOnTheFlyModifierTest.php
@@ -2,10 +2,10 @@
 
 namespace SIL\Tests;
 
-use SIL\PageContentLanguageModifier;
+use SIL\PageContentLanguageOnTheFlyModifier;
 
 /**
- * @covers \SIL\PageContentLanguageModifier
+ * @covers \SIL\PageContentLanguageOnTheFlyModifier
  * @group semantic-interlanguage-links
  *
  * @license GNU GPL v2+
@@ -13,7 +13,7 @@ use SIL\PageContentLanguageModifier;
  *
  * @author mwjames
  */
-class PageContentLanguageModifierTest extends \PHPUnit_Framework_TestCase {
+class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
@@ -26,8 +26,8 @@ class PageContentLanguageModifierTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SIL\PageContentLanguageModifier',
-			new PageContentLanguageModifier( $interlanguageLinksLookup, $cache )
+			'\SIL\PageContentLanguageOnTheFlyModifier',
+			new PageContentLanguageOnTheFlyModifier( $interlanguageLinksLookup, $cache )
 		);
 	}
 
@@ -51,7 +51,7 @@ class PageContentLanguageModifierTest extends \PHPUnit_Framework_TestCase {
 			->method( 'findPageLanguageForTarget' )
 			->will( $this->returnValue(  'ja' ) );
 
-		$instance = new PageContentLanguageModifier(
+		$instance = new PageContentLanguageOnTheFlyModifier(
 			$interlanguageLinksLookup,
 			$cache
 		);
@@ -85,7 +85,7 @@ class PageContentLanguageModifierTest extends \PHPUnit_Framework_TestCase {
 		$interlanguageLinksLookup->expects( $this->never() )
 			->method( 'findPageLanguageForTarget' );
 
-		$instance = new PageContentLanguageModifier(
+		$instance = new PageContentLanguageOnTheFlyModifier(
 			$interlanguageLinksLookup,
 			$cache
 		);
@@ -118,7 +118,7 @@ class PageContentLanguageModifierTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getCode' )
 			->will( $this->returnValue( 'en' ) );
 
-		$instance = new PageContentLanguageModifier(
+		$instance = new PageContentLanguageOnTheFlyModifier(
 			$interlanguageLinksLookup,
 			$cache
 		);
@@ -152,7 +152,7 @@ class PageContentLanguageModifierTest extends \PHPUnit_Framework_TestCase {
 			->method( 'findPageLanguageForTarget' )
 			->will( $this->returnValue( $invalidLanguageCode ) );
 
-		$instance = new PageContentLanguageModifier(
+		$instance = new PageContentLanguageOnTheFlyModifier(
 			$interlanguageLinksLookup,
 			$cache
 		);
@@ -186,7 +186,7 @@ class PageContentLanguageModifierTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PageContentLanguageModifier(
+		$instance = new PageContentLanguageOnTheFlyModifier(
 			$interlanguageLinksLookup,
 			$cache
 		);

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -42,7 +42,7 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$pageContentLanguageModifier = $this->getMockBuilder( '\SIL\PageContentLanguageModifier' )
+		$pageContentLanguageOnTheFlyModifier = $this->getMockBuilder( '\SIL\PageContentLanguageOnTheFlyModifier' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -52,7 +52,7 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		list( $name, $definition, $flag ) = $instance->newInterlanguageLinkParserFunctionDefinition(
 			$interlanguageLinksLookup,
-			$pageContentLanguageModifier
+			$pageContentLanguageOnTheFlyModifier
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
Override `page_lang` for cases where `wgPageLanguageUseDB` is enabled and the page language that was set via `Special:PageLanguage` is different from the annotated SIL pagecontent language.