### PR TITLE
Always return lowercase in getPageContentLanguage

### DIFF
--- a/src/PageContentLanguageOnTheFlyModifier.php
+++ b/src/PageContentLanguageOnTheFlyModifier.php
@@ -65,8 +65,11 @@ class PageContentLanguageOnTheFlyModifier {
 
 		$hash = $this->getHashFrom( $title );
 
+		// Convert language codes from BCP 47 to lowercase to ensure that codes
+		// are matchable against `Language::fetchLanguageNames` for languages like
+		// zh-Hans etc.
 		if ( ( $cachedLanguageCode = $this->intermediaryCache->fetch( $hash ) ) ) {
-			return $cachedLanguageCode;
+			return strtolower( $cachedLanguageCode );
 		}
 
 		$lookupLanguageCode = $this->interlanguageLinksLookup->findPageLanguageForTarget( $title );
@@ -78,6 +81,8 @@ class PageContentLanguageOnTheFlyModifier {
 		if ( $pageLanguage instanceof \Language ) {
 			$pageLanguage = $pageLanguage->getCode();
 		}
+
+		$pageLanguage = strtolower( $pageLanguage );
 
 		$this->intermediaryCache->save( $hash, $pageLanguage );
 

--- a/tests/phpunit/Unit/PageContentLanguageOnTheFlyModifierTest.php
+++ b/tests/phpunit/Unit/PageContentLanguageOnTheFlyModifierTest.php
@@ -49,7 +49,7 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit_Framework_TestCas
 
 		$interlanguageLinksLookup->expects( $this->once() )
 			->method( 'findPageLanguageForTarget' )
-			->will( $this->returnValue(  'ja' ) );
+			->will( $this->returnValue(  'zh-Hans' ) );
 
 		$instance = new PageContentLanguageOnTheFlyModifier(
 			$interlanguageLinksLookup,
@@ -57,7 +57,7 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit_Framework_TestCas
 		);
 
 		$this->assertEquals(
-			'ja',
+			'zh-hans',
 			$instance->getPageContentLanguage( $title, $pageLanguage )
 		);
 	}
@@ -76,7 +76,7 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit_Framework_TestCas
 
 		$cache->expects( $this->once() )
 			->method( 'fetch' )
-			->will( $this->returnValue(  'fr' ) );
+			->will( $this->returnValue(  'zh-Hans' ) );
 
 		$interlanguageLinksLookup = $this->getMockBuilder( '\SIL\InterlanguageLinksLookup' )
 			->disableOriginalConstructor()
@@ -91,7 +91,7 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit_Framework_TestCas
 		);
 
 		$this->assertEquals(
-			'fr',
+			'zh-hans',
 			$instance->getPageContentLanguage( $title, $pageLanguage )
 		);
 	}


### PR DESCRIPTION
Appease `Language::fetchLanguageNames` to return lowercased
languages codes.

https://github.com/wikimedia/mediawiki/blob/fc8481847a89ff82d0231b4e79c3002f6e816cde/includes/GlobalFunctions.php#L1358-L1362