### PR TITLE
Avoid use of deprecated wfBCP47() global function

### DIFF
--- a/src/AnnotatedLanguageParserFunction.php
+++ b/src/AnnotatedLanguageParserFunction.php
@@ -5,6 +5,8 @@ namespace SIL;
 use Title;
 use Language;
 
+use SMW\Localizer;
+
 /**
  * @license GNU GPL v2+
  * @since 1.4
@@ -69,7 +71,7 @@ class AnnotatedLanguageParserFunction {
 		$wikitext = '';
 
 		$wikitext .= "|target-link=" . $this->modifyTargetLink( $source );
-		$wikitext .= "|lang-code=" . wfBCP47( $languageCode );
+		$wikitext .= "|lang-code=" . Localizer::asBCP47FormattedLanguageCode( $languageCode );
 		$wikitext .= "|lang-name=" . Language::fetchLanguageName( $languageCode );
 
 		$templateText .= '{{' . $template . $wikitext . '}}';

--- a/src/InterlanguageLinkParserFunction.php
+++ b/src/InterlanguageLinkParserFunction.php
@@ -6,6 +6,8 @@ use Onoi\Cache\CacheFactory;
 use Title;
 use Language;
 
+use SMW\Localizer;
+
 /**
  * @license GNU GPL v2+
  * @since 1.0
@@ -97,7 +99,7 @@ class InterlanguageLinkParserFunction {
 	 */
 	public function parse( $languageCode, $linkReference ) {
 
-		$languageCode = wfBCP47( $languageCode );
+		$languageCode = Localizer::asBCP47FormattedLanguageCode( $languageCode );
 
 		// Keep reference while editing is on going to avoid a possible lag when
 		// a DV is trying to access the page content language

--- a/src/InterlanguageListParserFunction.php
+++ b/src/InterlanguageListParserFunction.php
@@ -5,6 +5,8 @@ namespace SIL;
 use Title;
 use Language;
 
+use SMW\Localizer;
+
 /**
  * @license GNU GPL v2+
  * @since 1.0
@@ -91,7 +93,7 @@ class InterlanguageListParserFunction {
 
 			$wikitext .= "|#=" . $i++;
 			$wikitext .= "|target-link=" . $this->modifyTargetLink( $targetLink );
-			$wikitext .= "|lang-code=" . wfBCP47( $languageCode );
+			$wikitext .= "|lang-code=" . Localizer::asBCP47FormattedLanguageCode( $languageCode );
 			$wikitext .= "|lang-name=" . Language::fetchLanguageName( $languageCode );
 
 			$templateText .= '{{' . $template . $wikitext . '}}';

--- a/src/Search/SearchResultModifier.php
+++ b/src/Search/SearchResultModifier.php
@@ -10,6 +10,8 @@ use Xml;
 use SearchResultSet;
 use SpecialSearch;
 
+use SMW\Localizer;
+
 /**
  * @license GNU GPL v2+
  * @since 1.0
@@ -148,7 +150,7 @@ class SearchResultModifier {
 			return false;
 		}
 
-		$languageCode = wfBCP47( $request->getVal( 'languagefilter' ) );
+		$languageCode = Localizer::asBCP47FormattedLanguageCode( $request->getVal( 'languagefilter' ) );
 
 		if ( in_array( $languageCode, array( null, '', '-' ) ) ) {
 			return false;


### PR DESCRIPTION
This was deprecated in MW 1.31.