### PR TITLE
Update tested environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ dist: trusty
 matrix:
   fast_finish: true
   include:
+    - env: DB=mysql; MW=REL1_31; PHPUNIT=5.7.*
+      php: 7.1
     - env: DB=mysql; MW=REL1_29; PHPUNIT=4.8.*; TYPE=coverage
       php: 5.6
     - env: DB=sqlite; MW=REL1_27; SITELANG=ja
-      php: 5.5
-    - env: DB=mysql; MW=master; PHPUNIT=4.8.*
-      php: 7.1
+      php: 5.6
+    - env: DB=mysql; MW=master; PHPUNIT=6.5.*
+      php: 7.2
   allow_failures:
     - env: DB=mysql; MW=master; PHPUNIT=4.8.*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ matrix:
     - env: DB=mysql; MW=REL1_29; PHPUNIT=4.8.*; TYPE=coverage
       php: 5.6
     - env: DB=sqlite; MW=REL1_27; SITELANG=ja
-      php: 5.6
+      php: 7.0
     - env: DB=mysql; MW=master; PHPUNIT=6.5.*
       php: 7.2
-  allow_failures:
-    - env: DB=mysql; MW=master; PHPUNIT=4.8.*
 
 install:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticInterlanguageLinks"
 	},
 	"require": {
-		"php": ">=5.5.0",
+		"php": ">=5.6.0",
 		"composer/installers": "1.*,>=1.0.1",
 		"onoi/cache": "~1.2",
 		"mediawiki/semantic-media-wiki": "~2.4|~3.0"


### PR DESCRIPTION
Refs: https://github.com/SemanticMediaWiki/SemanticInterlanguageLinks/issues/60

Raises minimum requirement for PHP to 5.6