### PR TITLE
[CI] Fix warnings and notices issued by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
+# https://docs.travis-ci.com/user/reference/overview/
 language: php
 
-# https://docs.travis-ci.com/user/trusty-ci-environment/
+os:
+  - linux
+
 dist: trusty
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - env: DB=mysql; MW=REL1_32; PHPUNIT=5.7.*


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- root: deprecated key sudo (The key `sudo` has no effect anymore.)
- root: key matrix is an alias for jobs, using jobs
- root: missing os, using the default linux

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #
