### PR TITLE
Prepare 2.1.0 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,14 @@
-This file contains the RELEASE-NOTES of the Semantic Interlanguage Links (a.k.a. SIL) extension.
+This file contains the RELEASE-NOTES of the **Semantic Interlanguage Links** (a.k.a. SIL) extension.
+
+### 2.1.0
+
+Released on (tentative date).
+
+* Minimum requirement for
+  * PHP changed to version 7.0 and later
+* #75 Removed search functionality now accessible via the [`SEARCH FORM SCHEMA`](https://www.semantic-mediawiki.org/wiki/Help:Schema/Type/SEARCH_FORM_SCHEMA) provided by Semantic MediaWiki
+* Localization updates from https://translatewiki.net
+
 
 ### 2.0.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,7 +5,7 @@ This file contains the RELEASE-NOTES of the **Semantic Interlanguage Links** (a.
 Released on (tentative date).
 
 * Minimum requirement for
-  * PHP changed to version 7.0 and later
+  * PHP changed to version 7.1 and later
 * #75 Removed search functionality now accessible via the [`SEARCH FORM SCHEMA`](https://www.semantic-mediawiki.org/wiki/Help:Schema/Type/SEARCH_FORM_SCHEMA) provided by Semantic MediaWiki
 * Localization updates from https://translatewiki.net
 

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,12 @@
 	"support": {
 		"email": "semediawiki-user@lists.sourceforge.net",
 		"issues": "https://github.com/SemanticMediaWiki/SemanticInterlanguageLinks/issues",
-		"irc": "irc://irc.freenode.net/semantic-mediawiki",
 		"forum": "https://www.semantic-mediawiki.org/wiki/semantic-mediawiki.org_talk:Community_portal",
 		"wiki": "https://www.semantic-mediawiki.org/wiki/",
 		"source": "https://github.com/SemanticMediaWiki/SemanticInterlanguageLinks"
 	},
 	"require": {
-		"php": ">=7.0",
+		"php": ">=7.1.0",
 		"composer/installers": "1.*,>=1.0.1",
 		"onoi/cache": "~1.2",
 		"mediawiki/semantic-media-wiki": "~3.0"


### PR DESCRIPTION
This PR is made in reference to: #80 

This PR addresses or contains:
- First version of the RELEASE-NOTES
- Updated "composer.json"

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
