### PR TITLE
Fix broken HookRegistryTest.php after switching to Language::factory

### DIFF
--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -2,6 +2,7 @@
 
 namespace SIL\Tests;
 
+use Language;
 use SIL\HookRegistry;
 use Title;
 
@@ -183,7 +184,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 	public function doTestPageContentLanguage( $instance ) {
 
 		$handler = 'PageContentLanguage';
-		$pageLang = '';
+		$pageLang = Language::factory( 'en' );
 
 		$title = Title::newFromText( __METHOD__ );
 


### PR DESCRIPTION
This PR is made in reference to: #88 

This PR addresses or contains:
- fix test by using use $pageLang = Language::factory( 'en' );

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #88
