### PR TITLE
Set up CI for SIL on 1.35

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       MW_DB_USER: wiki
       MW_DB_PWD: wiki
       MW_DB_NAME: wiki
-      extTargets: conf/extensions/SemanticInterlanguageLinks conf/extensions/SemanticMediaWiki
+      extTargets: SemanticInterlanguageLinks SemanticMediaWiki
       VERBOSE: 1
 
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,9 +59,6 @@ jobs:
           MARIADB_ROOT_PASSWORD: ${{ env.DB_ROOT_PWD }}
 
     steps:
-      - name: Get Composer
-        run: make composerBinaryInContainer
-
       - name: Checkout Extension
         uses: actions/checkout@v2
         with:
@@ -73,6 +70,9 @@ jobs:
         with:
           repository: SemanticMediaWiki/SemanticMediaWiki
           path: conf/extensions/SemanticMediaWiki
+
+      - name: Get Composer
+        run: make -f conf/extensions/${{ env.EXT_NAME }}/Makefile composerBinaryInContainer
 
       - name: Move extensions into place
         run: make setupExtensionsInContainer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,10 +49,10 @@ jobs:
       MW_DB_USER: wiki
       MW_DB_PWD: wiki
       MW_DB_NAME: wiki
-      VERBOSE: 1
       extTargets: >
         conf/extensions/SemanticInterlanguageLinks
         conf/extensions/SemanticMediaWiki
+      VERBOSE: 1
 
     services:
       some-mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
     env:
       mwExtensionUnderTest: SemanticInterlanguageLinks
       mwDepExtensions: SemanticMediaWiki
+      make: make -f conf/extensions/${{ env.mwExtensionUnderTest }}/Makefile
       COMPOSER_VERSION: 2
       MW_INSTALL_PATH: /var/www/html
       MW_EXT_PATH: /var/www/html/extensions
@@ -72,25 +73,25 @@ jobs:
           path: conf/extensions/SemanticMediaWiki
 
       - name: Get Composer
-        run: make -f conf/extensions/${{ env.mwExtensionUnderTest }}/Makefile composerBinaryInContainer
+        run: ${{ env.make }} composerBinaryInContainer
 
       - name: Move extensions into place
-        run: make setupExtensionsInContainer
+        run: ${{ env.make }} setupExtensionsInContainer
 
       - name: MediaWiki Composer Update
-        run: make runComposerInContainer
+        run: ${{ env.make }} runComposerInContainer
 
       - name: MediaWiki Install
-        run: make installExtensionInContainer
+        run: ${{ env.make }} installExtensionInContainer
 
       - name: Enable Debug Output
-        run: make enableDebugOutput
+        run: ${{ env.make }} enableDebugOutput
 
       - name: Install SemanticMediaWiki
-        run: make enableSemanticsAndUpdate
+        run: ${{ env.make }} enableSemanticsAndUpdate
 
-      - name: Fool the makefile
-        run: make buildOnGithub
+      - name: Fool the Makefile
+        run: ${{ env.make }} buildOnGithub
 
       - name: Run Tests
-        run: make testInContainer
+        run: ${{ env.make }} testInContainer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,7 @@ jobs:
       MW_DB_USER: wiki
       MW_DB_PWD: wiki
       MW_DB_NAME: wiki
-      extTargets: >
-        conf/extensions/SemanticInterlanguageLinks
-        conf/extensions/SemanticMediaWiki
+      extTargets: conf/extensions/SemanticInterlanguageLinks conf/extensions/SemanticMediaWiki
       VERBOSE: 1
 
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       mwExtensionUnderTest: SemanticInterlanguageLinks
       mwDepExtensions: SemanticMediaWiki
-      make: make -f conf/extensions/${{ env.mwExtensionUnderTest }}/Makefile
+      make: make -f conf/extensions/SemanticInterlanguageLinks/Makefile
       COMPOSER_VERSION: 2
       MW_INSTALL_PATH: /var/www/html
       MW_EXT_PATH: /var/www/html/extensions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,11 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - "**"
   pull_request:
-    branches: [ master ]
-  workflow_dispatch:
+    branches:
+      - "**"
 
 jobs:
   build:
@@ -15,6 +16,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - mediawiki_version: 1.35
+            database_type: sqlite
+            experimental: false
           - mediawiki_version: 1.35
             database_type: mysql
             experimental: false
@@ -30,7 +34,8 @@ jobs:
       options: --link some-${{ matrix.database_type }}:${{ matrix.database_type }}
 
     env:
-      EXT_NAME: SemanticInterlanguageLinks
+      mwExtensionUnderTest: SemanticInterlanguageLinks
+      mwDepExtensions: SemanticMediaWiki
       COMPOSER_VERSION: 2
       MW_INSTALL_PATH: /var/www/html
       MW_EXT_PATH: /var/www/html/extensions
@@ -38,10 +43,14 @@ jobs:
       DB_ROOT_PWD: database
       MW_DB_TYPE: ${{ matrix.database_type }}
       MW_DB_SERVER: ${{ matrix.database_type }}
+      mwVer: ${{matrix.mediawiki_version}}
       MW_DB_PATH: /var/www/data
       MW_DB_USER: wiki
       MW_DB_PWD: wiki
       MW_DB_NAME: wiki
+      extTargets: >
+        conf/extensions/SemanticInterlanguageLinks
+        conf/extensions/SemanticMediaWiki
 
     services:
       some-mysql:
@@ -50,77 +59,38 @@ jobs:
           MARIADB_ROOT_PASSWORD: ${{ env.DB_ROOT_PWD }}
 
     steps:
-      # https://getcomposer.org/download/
       - name: Get Composer
-        run: |
-          apt update
-          apt install -y unzip
-          php -r "copy('https://getcomposer.org/installer', 'installer');"
-          php -r "copy('https://composer.github.io/installer.sig', 'expected');"
-          echo `cat expected` " installer" | sha384sum -c -
-          php installer --${{ env.COMPOSER_VERSION }}
-          rm -f installer expected
-          mv composer.phar /usr/local/bin/composer
+        run: make composerBinaryInContainer
 
       - name: Checkout Extension
         uses: actions/checkout@v2
         with:
           repository: SemanticMediaWiki/${{ env.EXT_NAME }}
-          path: ${{ env.EXT_NAME }}
+          path: conf/extensions/${{ env.EXT_NAME }}
 
-      - name: Checkout SMW Extension
+      - name: Checkout SMW
         uses: actions/checkout@v2
         with:
           repository: SemanticMediaWiki/SemanticMediaWiki
-          path: SemanticMediaWiki
+          path: conf/extensions/SemanticMediaWiki
 
-      # Setting actions/checkout@v2 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
-      # See also open PR https://github.com/actions/checkout/pull/388
-      - name: Move Extension
-        run: |
-          mkdir -p ${{ env.MW_EXT_PATH }}
-          mv ${{ env.EXT_NAME }} ${{ env.MW_EXT_PATH }}
-          mv SemanticMediaWiki ${{ env.MW_EXT_PATH }}
+      - name: Move extensions into place
+        run: make setupExtensionsInContainer
 
       - name: MediaWiki Composer Update
-        run: |
-          COMPOSER=composer.local.json composer require --no-update --working-dir ${{ env.MW_INSTALL_PATH }} mediawiki/semantic-interlanguage-links @dev
-          COMPOSER=composer.local.json composer config repositories.semantic-interlanguage-links '{"type": "path", "url": "extensions/SemanticInterlanguageLinks"}' --working-dir ${{ env.MW_INSTALL_PATH }}
-          COMPOSER=composer.local.json composer require --no-update --working-dir ${{ env.MW_INSTALL_PATH }} mediawiki/semantic-media-wiki @dev
-          COMPOSER=composer.local.json composer config repositories.semantic-media-wiki '{"type": "path", "url": "extensions/SemanticMediaWiki"}' --working-dir ${{ env.MW_INSTALL_PATH }}
-          composer update --working-dir ${{ env.MW_INSTALL_PATH }}
+        run: make runComposerInContainer
 
       - name: MediaWiki Install
-        run: >
-          php ${{ env.MW_INSTALL_PATH }}/maintenance/install.php
-          --pass=Password123456
-          --server="http://localhost:8000"
-          --scriptpath=""
-          --dbtype=${{ env.MW_DB_TYPE }}
-          --dbserver=${{ env.MW_DB_SERVER }}
-          --installdbuser=${{ env.DB_ROOT_USER }}
-          --installdbpass=${{ env.DB_ROOT_PWD }}
-          --dbname=${{ env.MW_DB_NAME }}
-          --dbuser=${{ env.MW_DB_USER }}
-          --dbpass=${{ env.MW_DB_PWD }}
-          --dbpath=${{ env.MW_DB_PATH }}
-          --extensions=SemanticMediaWiki,SemanticInterlanguageLinks
-          ${{ env.EXT_NAME }}-test WikiSysop
+        run: make installExtensionInContainer
 
       - name: Enable Debug Output
-        run: |
-          echo 'error_reporting(E_ALL| E_STRICT);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo 'ini_set("display_errors", 1);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo '$wgShowExceptionDetails = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo '$wgDevelopmentWarnings = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+        run: make enableDebugOutput
 
       - name: Install SemanticMediaWiki
-        run: |
-          echo "enableSemantics( 'localhost' );" >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          tail -n5 ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          php ${{ env.MW_INSTALL_PATH }}/maintenance/update.php --quick
+        run: make enableSemanticsAndUpdate
+
+      - name: Fool the makefile
+        run: make buildOnGithub
 
       - name: Run Tests
-        run: >
-          composer phpunit
-          --working-dir ${{ env.MW_INSTALL_PATH }}/extensions/SemanticMediaWiki
+        run: make testInContainer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,126 @@
+name: build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      matrix:
+        include:
+          - mediawiki_version: 1.35
+            database_type: mysql
+            experimental: false
+          - mediawiki_version: 1.36
+            database_type: mysql
+            experimental: true
+          - mediawiki_version: 1.37
+            database_type: mysql
+            experimental: true
+
+    container:
+      image: mediawiki:${{ matrix.mediawiki_version }}
+      options: --link some-${{ matrix.database_type }}:${{ matrix.database_type }}
+
+    env:
+      EXT_NAME: SemanticInterlanguageLinks
+      COMPOSER_VERSION: 2
+      MW_INSTALL_PATH: /var/www/html
+      MW_EXT_PATH: /var/www/html/extensions
+      DB_ROOT_USER: root
+      DB_ROOT_PWD: database
+      MW_DB_TYPE: ${{ matrix.database_type }}
+      MW_DB_SERVER: ${{ matrix.database_type }}
+      MW_DB_PATH: /var/www/data
+      MW_DB_USER: wiki
+      MW_DB_PWD: wiki
+      MW_DB_NAME: wiki
+
+    services:
+      some-mysql:
+        image: mariadb:latest
+        env:
+          MARIADB_ROOT_PASSWORD: ${{ env.DB_ROOT_PWD }}
+
+    steps:
+      # https://getcomposer.org/download/
+      - name: Get Composer
+        run: |
+          apt update
+          apt install -y unzip
+          php -r "copy('https://getcomposer.org/installer', 'installer');"
+          php -r "copy('https://composer.github.io/installer.sig', 'expected');"
+          echo `cat expected` " installer" | sha384sum -c -
+          php installer --${{ env.COMPOSER_VERSION }}
+          rm -f installer expected
+          mv composer.phar /usr/local/bin/composer
+
+      - name: Checkout Extension
+        uses: actions/checkout@v2
+        with:
+          repository: SemanticMediaWiki/${{ env.EXT_NAME }}
+          path: ${{ env.EXT_NAME }}
+
+      - name: Checkout SMW Extension
+        uses: actions/checkout@v2
+        with:
+          repository: SemanticMediaWiki/SemanticMediaWiki
+          path: SemanticMediaWiki
+
+      # Setting actions/checkout@v2 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
+      # See also open PR https://github.com/actions/checkout/pull/388
+      - name: Move Extension
+        run: |
+          mkdir -p ${{ env.MW_EXT_PATH }}
+          mv ${{ env.EXT_NAME }} ${{ env.MW_EXT_PATH }}
+          mv SemanticMediaWiki ${{ env.MW_EXT_PATH }}
+
+      - name: MediaWiki Composer Update
+        run: |
+          COMPOSER=composer.local.json composer require --no-update --working-dir ${{ env.MW_INSTALL_PATH }} mediawiki/semantic-interlanguage-links @dev
+          COMPOSER=composer.local.json composer config repositories.semantic-interlanguage-links '{"type": "path", "url": "extensions/SemanticInterlanguageLinks"}' --working-dir ${{ env.MW_INSTALL_PATH }}
+          COMPOSER=composer.local.json composer require --no-update --working-dir ${{ env.MW_INSTALL_PATH }} mediawiki/semantic-media-wiki @dev
+          COMPOSER=composer.local.json composer config repositories.semantic-media-wiki '{"type": "path", "url": "extensions/SemanticMediaWiki"}' --working-dir ${{ env.MW_INSTALL_PATH }}
+          composer update --working-dir ${{ env.MW_INSTALL_PATH }}
+
+      - name: MediaWiki Install
+        run: >
+          php ${{ env.MW_INSTALL_PATH }}/maintenance/install.php
+          --pass=Password123456
+          --server="http://localhost:8000"
+          --scriptpath=""
+          --dbtype=${{ env.MW_DB_TYPE }}
+          --dbserver=${{ env.MW_DB_SERVER }}
+          --installdbuser=${{ env.DB_ROOT_USER }}
+          --installdbpass=${{ env.DB_ROOT_PWD }}
+          --dbname=${{ env.MW_DB_NAME }}
+          --dbuser=${{ env.MW_DB_USER }}
+          --dbpass=${{ env.MW_DB_PWD }}
+          --dbpath=${{ env.MW_DB_PATH }}
+          --extensions=SemanticMediaWiki,SemanticInterlanguageLinks
+          ${{ env.EXT_NAME }}-test WikiSysop
+
+      - name: Enable Debug Output
+        run: |
+          echo 'error_reporting(E_ALL| E_STRICT);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          echo 'ini_set("display_errors", 1);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          echo '$wgShowExceptionDetails = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          echo '$wgDevelopmentWarnings = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+
+      - name: Install SemanticMediaWiki
+        run: |
+          echo "enableSemantics( 'localhost' );" >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          tail -n5 ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          php ${{ env.MW_INSTALL_PATH }}/maintenance/update.php --quick
+
+      - name: Run Tests
+        run: >
+          composer phpunit
+          --working-dir ${{ env.MW_INSTALL_PATH }}/extensions/SemanticMediaWiki

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Checkout Extension
         uses: actions/checkout@v2
         with:
-          repository: SemanticMediaWiki/${{ env.EXT_NAME }}
-          path: conf/extensions/${{ env.EXT_NAME }}
+          repository: SemanticMediaWiki/${{ env.mwExtensionUnderTest }}
+          path: conf/extensions/${{ env.mwExtensionUnderTest }}
 
       - name: Checkout SMW
         uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
           path: conf/extensions/SemanticMediaWiki
 
       - name: Get Composer
-        run: make -f conf/extensions/${{ env.EXT_NAME }}/Makefile composerBinaryInContainer
+        run: make -f conf/extensions/${{ env.mwExtensionUnderTest }}/Makefile composerBinaryInContainer
 
       - name: Move extensions into place
         run: make setupExtensionsInContainer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
       MW_DB_USER: wiki
       MW_DB_PWD: wiki
       MW_DB_NAME: wiki
+      VERBOSE: 1
       extTargets: >
         conf/extensions/SemanticInterlanguageLinks
         conf/extensions/SemanticMediaWiki

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+!.*
 *~
+
 *.kate-swp
 
 vendor/
@@ -7,5 +9,9 @@ extensions/
 composer.phar
 composer.lock
 
-!.*
 .idea/
+
+.envrc
+.phpunit.result.cache
+conf/
+makeutil/

--- a/Makefile
+++ b/Makefile
@@ -180,13 +180,13 @@ ${mwCompLocal}:
 			--working-dir ${MW_INSTALL_PATH} mediawiki/semantic-interlanguage-links @dev		&&	\
 		COMPOSER=composer.local.json ${compPath} config repositories.semantic-interlanguage-links		\
 			'{"type": "path", "url": "extensions/SemanticInterlanguageLinks"}'                  	\
-            --working-dir ${{ env.MW_INSTALL_PATH }}											&&	\
+            --working-dir ${MW_INSTALL_PATH}											&&	\
           COMPOSER=composer.local.json ${compPath} require --no-update            						\
-            --working-dir ${{ env.MW_INSTALL_PATH }} mediawiki/semantic-media-wiki @dev			&&	\
+            --working-dir ${MW_INSTALL_PATH} mediawiki/semantic-media-wiki @dev			&&	\
           COMPOSER=composer.local.json ${compPath} config repositories.semantic-media-wiki				\
 			'{"type": "path", "url": "extensions/SemanticMediaWiki"}'								\
-            --working-dir ${{ env.MW_INSTALL_PATH }}											&&	\
-          ${compPath} update --working-dir ${{ env.MW_INSTALL_PATH }}								)
+            --working-dir ${MW_INSTALL_PATH}											&&	\
+          ${compPath} update --working-dir ${MW_INSTALL_PATH}								)
 	echo '*** debug'
 	cat $@
 

--- a/Makefile
+++ b/Makefile
@@ -200,11 +200,11 @@ pkgInContainer: verifyInContainerEnvVar
 		apt install -y $(if ${pkg},${pkg},${bin})												)
 
 .PHONY: SemanticMediaWiki
-SemanticMediaWiki: target=$@
+SemanticMediaWiki: target=SemanticMediaWiki
 SemanticMediaWiki: smwVCS
 
 .PHONY: SemanticInterlanguageLinks
-SemanticInterlanguageLinks: target=$@
+SemanticInterlanguageLinks: target=SemanticInterlanguageLinks
 SemanticInterlanguageLinks: smwVCS
 
 smwVCS:

--- a/Makefile
+++ b/Makefile
@@ -200,25 +200,22 @@ pkgInContainer: verifyInContainerEnvVar
 		apt install -y $(if ${pkg},${pkg},${bin})												)
 
 .PHONY: SemanticMediaWiki
-SemanticMediaWiki:
-	test ! -d ${mwCiExtensions}/$@															||	(	\
-		cd ${mwCiExtensions}/$@																	&&	\
-		test -z `git branch --show-current`														||
-			git pull																				\
-	)
-	test -d ${mwCiExtensions}/$@															||	(	\
-		git clone "https://github.com/SemanticMediaWiki/$@.git" ${mwCiExtensions}/$@				\
-	)
+SemanticMediaWiki: target=$@
+SemanticMediaWiki: smwVCS
 
 .PHONY: SemanticInterlanguageLinks
-SemanticInterlanguageLinks:
-	test ! -d ${mwCiExtensions}/$@															||	(	\
-		cd ${mwCiExtensions}/$@																	&&	\
-		echo ${indent}"Updating $@ from "`git remote get-url origin`							&&	\
-		git pull																					\
+SemanticInterlanguageLinks: target=$@
+SemanticInterlanguageLinks: smwVCS
+
+smwVCS:
+	test ! -d ${mwCiExtensions}/${target}													||	(	\
+		cd ${mwCiExtensions}/${target}															&&	\
+		test -z "`git branch --show-current`"													||	\
+			git pull																				\
 	)
-	test -d ${mwCiExtensions}/$@															||	(	\
-		git clone "https://github.com/SemanticMediaWiki/$@.git" ${mwCiExtensions}/$@				\
+	test -d ${mwCiExtensions}/${target}														||	(	\
+		git clone "https://github.com/SemanticMediaWiki/${target}.git"								\
+			${mwCiExtensions}/${target}																\
 	)
 
 setupExtensionsInContainer: ${extTargets}

--- a/Makefile
+++ b/Makefile
@@ -203,8 +203,8 @@ pkgInContainer: verifyInContainerEnvVar
 SemanticMediaWiki:
 	test ! -d ${mwCiExtensions}/$@															||	(	\
 		cd ${mwCiExtensions}/$@																	&&	\
-		echo ${indent}"Updating $@ from "`git remote get-url origin`							&&	\
-		git pull																					\
+		test -z `git branch --show-current`														||
+			git pull																				\
 	)
 	test -d ${mwCiExtensions}/$@															||	(	\
 		git clone "https://github.com/SemanticMediaWiki/$@.git" ${mwCiExtensions}/$@				\

--- a/Makefile
+++ b/Makefile
@@ -178,11 +178,13 @@ ${mwCompLocal}:
 		echo {} > $@																	)	||	(	\
 		COMPOSER=$@ ${compPath} require --no-update mediawiki/semantic-interlanguage-links @dev	&&	\
 		COMPOSER=$@ ${compPath} config repositories.semantic-interlanguage-links					\
+			 --working-dir ${MW_INSTALL_PATH}														\
 			'{"type": "path", "url": "extensions/SemanticInterlanguageLinks"}'					&&	\
 		COMPOSER=$@ ${compPath} require --no-update mediawiki/semantic-media-wiki @dev			&&	\
-		COMPOSER=$@ ${compPath} config repositories.semantic-media-wiki								\
+		COMPOSER=$@ ${compPath} config repositories.semantic-media-wiki 							\
+			 --working-dir ${MW_INSTALL_PATH}														\
 			'{"type": "path", "url": "extensions/SemanticMediaWiki"}'							&&	\
-		${compPath} update --working-dir ${MW_INSTALL_PATH}								)
+		${compPath} update --working-dir ${MW_INSTALL_PATH}										)
 	echo '*** debug'
 	cat $@ ${mwCompLocal}
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,228 @@
+include makeutil/baseConfig.mk
+
+SHELL=bash
+
+git:
+	type $@ > /dev/null 2>&1 || ( echo $@ is not installed; exit 10 )
+
+#
+makeutil/baseConfig.mk: git
+	test -f $@																					||	\
+		git clone "https://phabricator.nichework.com/source/makefile-skeleton" makeutil
+
+# Name of the extension under test
+mwExtensionUnderTest ?= Set-mwExtensionUnderTest
+# Name of the branch under test
+mwExtGitBranchUnderTest ?= $(shell git branch --show-current)
+# Any dependent extensions
+mwDepExtensions ?=
+# PHPUnit will look for this string and filter by it
+mwTestFilter ?=
+# PHPUnit will run tests in this group
+mwTestGroup ?=
+# PHPUnit will run tests in this path (relative to MW_INSTALL_PATH)
+mwTestPath ?=
+
+#
+getPackagistUnderTest=test ! -f composer.json || ( jq -Mr .name < composer.json )
+packagistVersion ?= dev-${mwExtGitBranchUnderTest}
+
+# Image name
+mwImage ?= mediawiki
+# Version to test
+mwVer ?= 1.35
+
+# Image based on image name + version
+#
+containerID ?= ${mwImage}:${mwVer}
+
+# These are based on the image
+#
+MW_INSTALL_PATH ?= /var/www/html
+WEB_GROUP ?= www-data
+WEB_USER ?= www-data
+WEB_ROOT ?= /var/www
+
+# Setting up the wiki
+#
+MW_DB_TYPE ?= sqlite
+MW_DB_NAME ?= my_wiki
+MW_DATA_DIR ?= /var/www/data
+MW_PASSWORD ?= ugly123456
+MW_WIKI_USER ?= WikiSysop
+MW_SCRIPTPATH ?= ""
+
+# Name of the wiki
+MW_SITE_NAME ?= ${mwExtensionUnderTest}
+
+#
+mwCiPath ?= ${PWD}/conf
+composerPhar ?= ${mwCiPath}/composer.phar
+phpIni ?= ${mwCiPath}/php-settings.ini
+mwBranch ?= $(shell echo ${mwVer} | (echo -n REL; tr . _))
+dockerCli ?= podman
+miniSudo ?= podman unshare
+mwImgVersion ?= mediawiki:${mwVer}
+memcImgVersion ?= docker.io/library/memcached:latest
+mwDomain ?= localhost
+logDir ?= ${PWD}/logs
+mwWebPort ?= 8000
+mwContainer ?= mediawiki-${mwExtensionUnderTest}
+mwWebUser ?= www-data:www-data
+mwDbPath ?= ${mwCiPath}/sqlite-data
+mwVendor ?= ${mwCiPath}/vendor
+mwAptPath ?= ${mwCiPath}/apt
+mwDotComposer ?= ${mwCiPath}/dot-composer
+mwExtensions ?= ${mwCiPath}/extensions
+mwSkins ?= ${mwCiPath}/skins
+thisRepoCopy ?= ${mwExtensions}/${mwExtensionUnderTest}
+contPath ?= /var/www/html
+mwContPath ?= ${contPath}
+compPath ?= ${contPath}/composer
+extPath ?= ${mwContPath}/extensions/${mwExtensionUnderTest}
+importData ?= test-data/import.xml
+phpunitOptions ?= --testdox
+autoloadClassmap ?= ${mwVendor}/composer/autoload_classmap.php
+
+# Comma seperated list of extensions to install
+installExtensions ?=
+
+lsPath=${mwCiPath}/LocalSettings.php
+mwCompLocal=${mwCiPath}/composer.local.json
+
+# Run phpunit tests for this extension
+test: build.tar.gz pullContainer
+	${make} inContainer target=testInContainer
+
+# Build test environment for this extension
+build: pullContainer
+	test -f ${mwCiPath}/build.tar.gz															&&	\
+		echo "build.tar.gz already exists, not re-creating."									||	\
+		${make} inContainer target=buildInContainer
+
+#
+${phpIni}: MW_CI_PATH
+	test -z "$@" -o -f "$@"															||	(			\
+		echo '[PHP]'																			&&	\
+		echo 'error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE'			)	>	$@
+
+.PHONY: pullContainer
+pullContainer:
+	export hasIt=`${dockerCli} images -q ${containerID}`										&&	\
+	test -n "$$hasIt"																			&&	\
+		echo "The container (${containerID}) does not need to be pulled again."					||	\
+		${dockerCli} pull ${containerID}
+
+build.tar.gz: build
+
+verifyInContainerEnvVar:
+	test -n "${mwExtensionUnderTest}" 														||	(	\
+		echo "You must set the mwExtensionUnderTest variable."									&&	\
+		echo "See <http://hexm.de/glcivar>"; exit 10											)
+
+inContainer:
+	test -n "${target}" 																	||	(	\
+		echo "You must specify a target for the container to execute"							&&	\
+		echo "See <http://hexm.de/glcivar>"; exit 10											)
+	mkdir -p ${mwVendor}
+	${dockerCli} run --rm -w /target -v "${PWD}:/target" ${containerID}								\
+		make ${target} VERBOSE=${VERBOSE} phpunitOptions="${phpunitOptions}" 						\
+			mwExtensionUnderTest="${mwExtensionUnderTest}" mwTestGroup="${mwTestGroup}"				\
+			mwTestFilter="${mwTestFilter}" mwTestPath="${mwTestPath}" WEB_GROUP="${WEB_GROUP}"		\
+			MW_INSTALL_PATH="${MW_INSTALL_PATH}" WEB_ROOT="${WEB_ROOT}" WEB_USER="${WEB_USER}"		\
+			mwDepExtensions=${mwDepExtensions}
+
+linkInContainer:
+	test -L ${target}																		||	(	\
+		echo ${indent}"Linking target (${target}) to source (${src}) in container..."	&&			\
+		test ! -e ${src}																||	(		\
+			echo ${indent}"Source exists, not copying"										&&		\
+			rm -rf ${target}																		\
+		)																				&&			\
+		test ! -e ${target}																||	(		\
+			echo ${indent}"Copying source initially."										&&		\
+			cp -pr ${target} ${src}															&&		\
+			rm -rf ${target}																		\
+		)																						&&	\
+		ln -s ${src} ${target}																		\
+	)
+
+composerBinaryInContainer:
+	${make} pkgInContainer bin=unzip
+	echo ${indent}"Getting composer..."
+	test -x ${composerPhar}																	||	(	\
+		cd ${mwCiPath}																			&&	\
+		curl -o installer "https://getcomposer.org/installer"									&&	\
+		curl -o expected "https://composer.github.io/installer.sig"								&&	\
+		echo `cat expected` " installer" | sha384sum -c -										&&	\
+		php installer																			)
+
+${mwCompLocal}:
+	${make} pkgInContainer bin=jq
+	export packagistUnderTest=`$(call getPackagistUnderTest)`									&&	\
+	test -z "$$packagistUnderTest"													&&	(			\
+		echo {} > $@																	)	||	(	\
+		echo {}																					|	\
+		jq ".require.\"mediawiki/semantic-media-wiki\" = \"dev-master\""						|	\
+		jq ".require.\"$$packagistUnderTest\" = \"dev-${mwExtGitBranchUnderTest}\""				|	\
+		jq '. += { repositories: [{"type":"vcs","url":"${PWD}"}]}' > $@						)
+
+linksInContainer: ${mwCompLocal}
+	echo ${indent}"Setting up symlinks for container"
+	${make} linkInContainer target=${MW_INSTALL_PATH}/extensions/${mwExtensionUnderTest} src=${PWD}
+	${make} linkInContainer target=${MW_INSTALL_PATH}/vendor              src=${mwVendor}
+	${make} linkInContainer target=${MW_INSTALL_PATH}/composer.local.json src=${mwCompLocal}
+	${make} linkInContainer target=${MW_INSTALL_PATH}/composer.lock       src=${mwCiPath}/composer.lock
+	${make} linkInContainer target=${MW_INSTALL_PATH}/composer.json       src=${mwCiPath}/composer.json
+
+pkgInContainer: verifyInContainerEnvVar
+	type ${bin} > /dev/null 2>&1 															||	(	\
+		echo ${indent}"Installing $(if ${pkg},${pkg},${bin})..."								&&	\
+		apt update																				&&	\
+		apt install -y $(if ${pkg},${pkg},${bin})												)
+
+runComposerInContainer: verifyInContainerEnvVar
+	${make} pkgInContainer bin=unzip
+	echo ${indent}"Running composer..."
+	php ${composerPhar} update --working-dir ${MW_INSTALL_PATH}
+
+installExtensionInContainer: verifyInContainerEnvVar
+	echo ${indent}"Installing MediaWiki for ${mwExtensionUnderTest}..."
+	mkdir -p ${mwCiPath}/data
+	php ${MW_INSTALL_PATH}/maintenance/install.php --dbtype=sqlite --dbname=mywiki					\
+			  --pass=ugly123456 --scriptpath="" --dbpath=${mwCiPath}/data							\
+			  --server="http://localhost:8000"														\
+			  --extensions=${mwDepExtensions},${mwExtensionUnderTest}								\
+			  ${mwExtensionUnderTest}-test WikiSysop
+	${make} linkInContainer target=${MW_INSTALL_PATH}/LocalSettings.php src=${mwCiPath}/LocalSettings.php
+	echo 'error_reporting(E_ALL| E_STRICT);' >> ${mwCiPath}/LocalSettings.php
+	echo 'ini_set("display_errors", 1);' >> ${mwCiPath}/LocalSettings.php
+	echo '$$wgShowExceptionDetails = true;' >> ${mwCiPath}/LocalSettings.php
+	echo '$$wgDevelopmentWarnings = true;' >> ${mwCiPath}/LocalSettings.php
+	echo "enableSemantics( 'localhost' );" >> ${mwCiPath}/LocalSettings.php
+	echo "wfLoadExtension( '${mwExtensionUnderTest}' );" >> ${mwCiPath}/LocalSettings.php
+	php ${MW_INSTALL_PATH}/maintenance/update.php --quick
+	chown -R "${WEB_USER}:${WEB_GROUP}" ${mwCiPath}/data
+
+buildInContainer: verifyInContainerEnvVar
+	test -f ${mwCiPath}/build.tar.gz 														||	(	\
+		${make} composerBinaryInContainer														&&	\
+		${make} linksInContainer																&&	\
+		${make} runComposerInContainer															&&	\
+		${make} installExtensionInContainer														&&	\
+		echo ${indent}"Creating build.tar.gz"													&&	\
+		tar -C ${mwCiPath} -cf ${mwCiPath}/build.tar	 											\
+			LocalSettings.php composer.local.json composer.json composer.lock vendor data		&&	\
+		tar -C ${MW_INSTALL_PATH}/extensions -rf ${mwCiPath}/build.tar SemanticMediaWiki		&&	\
+		gzip ${mwCiPath}/build.tar																	\
+	)
+
+testInContainer: buildInContainer verifyInContainerEnvVar
+	tar -C ${mwCiPath} -xzf ${mwCiPath}/build.tar.gz
+	${make} linksInContainer
+	${make} linkInContainer target=${MW_INSTALL_PATH}/extensions/SemanticMediaWiki					\
+							src=${mwCiPath}/SemanticMediaWiki
+	${make} linkInContainer target=${MW_INSTALL_PATH}/LocalSettings.php 							\
+							src=${mwCiPath}/LocalSettings.php
+	cd ${MW_INSTALL_PATH}/extensions/${mwExtensionUnderTest}									&&	\
+		php ${composerPhar} test --working-dir=${MW_INSTALL_PATH}/extensions/${mwExtensionUnderTest}

--- a/Makefile
+++ b/Makefile
@@ -176,19 +176,15 @@ ${mwCompLocal}:
 	export packagistUnderTest=`$(call getPackagistUnderTest)`									&&	\
 	test -z "$$packagistUnderTest"													&&	(			\
 		echo {} > $@																	)	||	(	\
-		COMPOSER=composer.local.json ${compPath} require --no-update									\
-			--working-dir ${MW_INSTALL_PATH} mediawiki/semantic-interlanguage-links @dev		&&	\
-		COMPOSER=composer.local.json ${compPath} config repositories.semantic-interlanguage-links		\
-			'{"type": "path", "url": "extensions/SemanticInterlanguageLinks"}'                  	\
-            --working-dir ${MW_INSTALL_PATH}											&&	\
-          COMPOSER=composer.local.json ${compPath} require --no-update            						\
-            --working-dir ${MW_INSTALL_PATH} mediawiki/semantic-media-wiki @dev			&&	\
-          COMPOSER=composer.local.json ${compPath} config repositories.semantic-media-wiki				\
-			'{"type": "path", "url": "extensions/SemanticMediaWiki"}'								\
-            --working-dir ${MW_INSTALL_PATH}											&&	\
-          ${compPath} update --working-dir ${MW_INSTALL_PATH}								)
+		COMPOSER=$@ ${compPath} require --no-update mediawiki/semantic-interlanguage-links @dev	&&	\
+		COMPOSER=$@ ${compPath} config repositories.semantic-interlanguage-links					\
+			'{"type": "path", "url": "extensions/SemanticInterlanguageLinks"}'					&&	\
+		COMPOSER=$@ ${compPath} require --no-update mediawiki/semantic-media-wiki @dev			&&	\
+		COMPOSER=$@ ${compPath} config repositories.semantic-media-wiki								\
+			'{"type": "path", "url": "extensions/SemanticMediaWiki"}'							&&	\
+		${compPath} update --working-dir ${MW_INSTALL_PATH}								)
 	echo '*** debug'
-	cat $@
+	cat $@ ${mwCompLocal}
 
 pkgInContainer: verifyInContainerEnvVar
 	type ${bin} > /dev/null 2>&1 															||	(	\

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ mwSkins ?= ${mwCiPath}/skins
 contPath ?= /var/www/html
 mwContPath ?= ${contPath}
 compPath ?= ${contPath}/composer
-extPath ?= ${mwContPath}/extensions/${mwExtensionUnderTest}
+extensionsPath ?= ${mwContPath}/extensions
 importData ?= test-data/import.xml
 phpunitOptions ?= --testdox
 autoloadClassmap ?= ${mwVendor}/composer/autoload_classmap.php
@@ -194,7 +194,9 @@ pkgInContainer: verifyInContainerEnvVar
 
 setupExtensionsInContainer: ${extTargets}
 	for i in ${extTargets}; do																		\
-		mv $$i $
+		export basename=`basename $$i`															&&	\
+		${make} linkInContainer target=${extensionsPath}/$$basename src=${PWD}/$$i				;	\
+	done
 
 runComposerInContainer: verifyInContainerEnvVar
 	${make} pkgInContainer bin=unzip

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ WEB_ROOT ?= /var/www
 #
 MW_DB_TYPE ?= sqlite
 MW_DB_NAME ?= my_wiki
+MW_DB_SERVER ?= localhost
 MW_DB_PATH ?= ${mwCiPath}/data
 MW_DB_USER ?= wikiuser
 MW_DB_PASS ?= wikipass
@@ -208,8 +209,8 @@ installExtensionInContainer: verifyInContainerEnvVar
 	echo ${indent}"Installing MediaWiki for ${mwExtensionUnderTest}..."
 	mkdir -p ${mwCiPath}/data
 	php ${MW_INSTALL_PATH}/maintenance/install.php --dbtype=${MW_DB_TYPE} --dbname=mywiki			\
-			--dbserver=${MD_DB_SERVER} --dbuser=${MW_DB_USER} --dbpass=${MW_DB_PASS}				\
-			--installdbuser=${DB_ROOT_PASS} --installdbpass=${DB_ROOT_PWD} --pass=${MW_PASSWORD}	\
+			--dbserver=${MW_DB_SERVER} --dbuser=${MW_DB_USER} --dbpass=${MW_DB_PASS}				\
+			--installdbuser=${DB_ROOT_USER} --installdbpass=${DB_ROOT_PWD} --pass=${MW_PASSWORD}	\
 			--scriptpath=${MW_SCRIPTPATH} --dbpath=${MW_DB_PATH} --server="http://localhost:8000"	\
 			--extensions=${mwDepExtensions},${mwExtensionUnderTest}									\
 			${mwExtensionUnderTest}-test ${MW_WIKI_USER}

--- a/Makefile
+++ b/Makefile
@@ -176,17 +176,17 @@ ${mwCompLocal}:
 	export packagistUnderTest=`$(call getPackagistUnderTest)`									&&	\
 	test -z "$$packagistUnderTest"													&&	(			\
 		echo {} > $@																	)	||	(	\
-		COMPOSER=$@ ${compPath} require --no-update mediawiki/semantic-interlanguage-links @dev	&&	\
-		COMPOSER=$@ ${compPath} config repositories.semantic-interlanguage-links					\
-			 --working-dir ${MW_INSTALL_PATH}														\
+		COMPOSER=composer.local.json ${compPath} require --no-update								\
+			 --working-dir=${MW_INSTALL_PATH} mediawiki/semantic-interlanguage-links @dev		&&	\
+		COMPOSER=composer.local.json ${compPath} config repositories.semantic-interlanguage-links	\
+			 --working-dir=${MW_INSTALL_PATH}														\
 			'{"type": "path", "url": "extensions/SemanticInterlanguageLinks"}'					&&	\
-		COMPOSER=$@ ${compPath} require --no-update mediawiki/semantic-media-wiki @dev			&&	\
-		COMPOSER=$@ ${compPath} config repositories.semantic-media-wiki 							\
-			 --working-dir ${MW_INSTALL_PATH}														\
+		COMPOSER=composer.local.json ${compPath} require --no-update								\
+			 --working-dir=${MW_INSTALL_PATH} mediawiki/semantic-media-wiki @dev				&&	\
+		COMPOSER=composer.local.json ${compPath} config repositories.semantic-media-wiki 			\
+			 --working-dir=${MW_INSTALL_PATH}														\
 			'{"type": "path", "url": "extensions/SemanticMediaWiki"}'							&&	\
-		${compPath} update --working-dir ${MW_INSTALL_PATH}										)
-	echo '*** debug'
-	cat $@ ${mwCompLocal}
+		${compPath} update --working-dir=${MW_INSTALL_PATH}										)
 
 pkgInContainer: verifyInContainerEnvVar
 	type ${bin} > /dev/null 2>&1 															||	(	\

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,8 @@ ${mwCompLocal}:
 			'{"type": "path", "url": "extensions/SemanticMediaWiki"}'								\
             --working-dir ${{ env.MW_INSTALL_PATH }}											&&	\
           composer update --working-dir ${{ env.MW_INSTALL_PATH }}								)
+	echo '*** debug'
+	cat $@
 
 pkgInContainer: verifyInContainerEnvVar
 	type ${bin} > /dev/null 2>&1 															||	(	\

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ MW_SITE_NAME ?= ${mwExtensionUnderTest}
 binDir ?= /usr/local/bin
 actUrl ?= https://github.com/nektos/act
 mwCiPath ?= ${PWD}/conf
-composerPhar ?= ${mwCiPath}/composer.phar
 phpIni ?= ${mwCiPath}/php-settings.ini
 mwBranch ?= $(shell echo ${mwVer} | (echo -n REL; tr . _))
 dockerCli ?= podman
@@ -203,7 +202,7 @@ setupExtensionsInContainer: ${extTargets}
 runComposerInContainer: verifyInContainerEnvVar ${mwCompLocal}
 	${make} pkgInContainer bin=unzip
 	echo ${indent}"Running composer..."
-	php ${composerPhar} update --working-dir ${MW_INSTALL_PATH}
+	php ${compPath} update --working-dir ${MW_INSTALL_PATH}
 
 installExtensionInContainer: verifyInContainerEnvVar
 	echo ${indent}"Installing MediaWiki for ${mwExtensionUnderTest}..."
@@ -266,4 +265,4 @@ testInContainer: buildInContainer verifyInContainerEnvVar
 	${make} linkInContainer target=${MW_INSTALL_PATH}/LocalSettings.php 							\
 							src=${mwCiPath}/LocalSettings.php
 	cd ${MW_INSTALL_PATH}/extensions/${mwExtensionUnderTest}									&&	\
-		php ${composerPhar} test --working-dir=${MW_INSTALL_PATH}/extensions/${mwExtensionUnderTest}
+		php ${compPath} test --working-dir=${MW_INSTALL_PATH}/extensions/${mwExtensionUnderTest}

--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,9 @@ actInstall:
 localTestGithub: actInstall
 	act $(if ${VERBOSE},--verbose)
 
+# From https://www.wezm.net/technical/2008/03/create-empty-tar-file/
 buildOnGithub:
-	touch ${mwCiPath}/build.tar.gz
+	tar czf ${mwCiPath}/build.tar.gz --files-from /dev/null
 
 buildInContainer: verifyInContainerEnvVar
 	test -f ${mwCiPath}/build.tar.gz 														||	(	\

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ setupExtensionsInContainer: ${extTargets}
 		${make} linkInContainer target=${extensionsPath}/$$basename src=${PWD}/$$i				;	\
 	done
 
-runComposerInContainer: verifyInContainerEnvVar
+runComposerInContainer: verifyInContainerEnvVar ${mwCompLocal}
 	${make} pkgInContainer bin=unzip
 	echo ${indent}"Running composer..."
 	php ${composerPhar} update --working-dir ${MW_INSTALL_PATH}

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ enableDebugOutput:
 	echo 'ini_set("display_errors", 1);' >> ${mwCiPath}/LocalSettings.php
 	echo '$$wgShowExceptionDetails = true;' >> ${mwCiPath}/LocalSettings.php
 	echo '$$wgDevelopmentWarnings = true;' >> ${mwCiPath}/LocalSettings.php
+	cat ${mwCiPath}/LocalSettings.php
 
 enableSemanticsAndUpdate:
 	echo "enableSemantics( 'localhost' );" >> ${mwCiPath}/LocalSettings.php

--- a/SemanticInterlanguageLinks.php
+++ b/SemanticInterlanguageLinks.php
@@ -6,38 +6,17 @@ use SMW\ApplicationFactory;
 use Onoi\Cache\CacheFactory;
 
 /**
- * @see https://github.com/SemanticMediaWiki/SemanticInterlanguageLinks/
- *
- * @defgroup SIL Semantic Interlanguage Links
- */
-SemanticInterlanguageLinks::load();
-
-/**
  * @codeCoverageIgnore
  */
 class SemanticInterlanguageLinks {
 
 	/**
-	 * @since 1.4
-	 *
-	 * @note It is expected that this function is loaded before LocalSettings.php
-	 * to ensure that settings and global functions are available by the time
-	 * the extension is activated.
-	 */
-	public static function load() {
-
-		if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
-			include_once __DIR__ . '/vendor/autoload.php';
-		}
-
-		// Load DefaultSettings
-		require_once __DIR__ . '/DefaultSettings.php';
-	}
-
-	/**
 	 * @since 1.3
 	 */
 	public static function initExtension( $credits = [] ) {
+
+		// Load DefaultSettings
+		require_once __DIR__ . '/DefaultSettings.php';
 
 		// See https://phabricator.wikimedia.org/T151136
 		define( 'SIL_VERSION', isset( $credits['version'] ) ? $credits['version'] : 'UNKNOWN' );

--- a/SemanticInterlanguageLinks.php
+++ b/SemanticInterlanguageLinks.php
@@ -54,14 +54,6 @@ class SemanticInterlanguageLinks {
 	 */
 	public static function onExtensionFunction() {
 
-		if ( !defined( 'SMW_VERSION' ) ) {
-			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {
-				die( "\nThe 'Semantic Interlanguage Links' extension requires 'Semantic MediaWiki' to be installed and enabled.\n" );
-			} else {
-				die( '<b>Error:</b> The <a href="https://github.com/SemanticMediaWiki/SemanticInterlanguageLinks/">Semantic Interlanguage Links</a> extension requires <a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki">Semantic MediaWiki</a> to be installed and enabled.<br />' );
-			}
-		}
-
 		// Legacy
 		if ( isset( $GLOBALS['egSILEnabledCategoryFilterByLanguage'] ) ) {
 			$GLOBALS['silgEnabledCategoryFilterByLanguage'] = $GLOBALS['egSILEnabledCategoryFilterByLanguage'];

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
 		"process-timeout": 0
 	},
 	"scripts":{
-		"test": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
-		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist"
+		"test": "php ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
+		"phpunit": "php ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
 		}
 	},
 	"autoload": {
-		"files" : [
-			"SemanticInterlanguageLinks.php"
-		],
+		"psr-0": {
+			"SemanticInterlanguageLinks": "SemanticInterlanguageLinks.php"
+		},
 		"psr-4": {
 			"SIL\\": "src/"
 		}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"php": ">=7.1.0",
 		"composer/installers": "1.*,>=1.0.1",
 		"onoi/cache": "~1.2",
-		"mediawiki/semantic-media-wiki": "~3.0"
+		"mediawiki/semantic-media-wiki": "~3.0|@dev"
 	},
 	"require-dev": {
 		"mediawiki/semantic-media-wiki": "@dev"

--- a/extension.json
+++ b/extension.json
@@ -11,10 +11,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.31",
-		"extensions": {
-			"SemanticMediaWiki": ">= 3.0"
-		}
+		"MediaWiki": ">= 1.31"
 	},
 	"MessagesDirs": {
 		"SemanticInterlanguageLinks": [

--- a/extension.json
+++ b/extension.json
@@ -19,6 +19,12 @@
 		]
 	},
 	"callback": "SemanticInterlanguageLinks::initExtension",
+	"AutoloadClasses": {
+		"SemanticInterlanguageLinks": "SemanticInterlanguageLinks.php"
+	},
+	"AutoloadNamespaces": {
+		"SIL\\": "src/"
+	},
 	"ExtensionFunctions": [
 		"SemanticInterlanguageLinks::onExtensionFunction"
 	],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,8 @@ error_reporting( E_ALL | E_STRICT );
 date_default_timezone_set( 'UTC' );
 ini_set( 'display_errors', 1 );
 
-if ( !is_readable( $autoloaderClassPath = __DIR__ . '/../../SemanticMediaWiki/tests/autoloader.php' ) ) {
+$autoloaderClassPath = getenv( "MW_INSTALL_PATH" ) . '/extensions/SemanticMediaWiki/tests/autoloader.php';
+if ( !is_readable( $autoloaderClassPath  ) ) {
 	die( 'The Semantic MediaWiki test autoloader is not available' );
 }
 

--- a/tests/phpunit/Unit/Category/LanguageFilterCategoryViewerTest.php
+++ b/tests/phpunit/Unit/Category/LanguageFilterCategoryViewerTest.php
@@ -18,7 +18,7 @@ class LanguageFilterCategoryViewerTest extends \PHPUnit_Framework_TestCase {
 
 	private $context;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$config = $this->getMockBuilder( '\Config' )

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -21,7 +21,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 	private $store;
 	private $cacheKeyProvider;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )

--- a/tests/phpunit/Unit/InterlanguageLinkParserFunctionTest.php
+++ b/tests/phpunit/Unit/InterlanguageLinkParserFunctionTest.php
@@ -20,7 +20,7 @@ class InterlanguageLinkParserFunctionTest extends \PHPUnit_Framework_TestCase {
 	private $pageContentLanguageOnTheFlyModifier;
 	private $pageContentLanguageDbModifier;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->languageLinkAnnotator = $this->getMockBuilder( '\SIL\LanguageLinkAnnotator' )

--- a/tests/phpunit/Unit/InterlanguageLinksLookupTest.php
+++ b/tests/phpunit/Unit/InterlanguageLinksLookupTest.php
@@ -23,7 +23,7 @@ class InterlanguageLinksLookupTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )

--- a/tests/phpunit/Unit/InterwikiLanguageLinkTest.php
+++ b/tests/phpunit/Unit/InterwikiLanguageLinkTest.php
@@ -19,7 +19,7 @@ use Title;
  */
 class InterwikiLanguageLinkTest extends \PHPUnit_Framework_TestCase {
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$propertyRegistry = $this->getMockBuilder( '\SMW\PropertyRegistry' )

--- a/tests/phpunit/Unit/LanguageLinkAnnotatorTest.php
+++ b/tests/phpunit/Unit/LanguageLinkAnnotatorTest.php
@@ -19,7 +19,7 @@ use SMW\DIWikiPage;
  */
 class LanguageLinkAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$propertyRegistry = $this->getMockBuilder( '\SMW\PropertyRegistry' )

--- a/tests/phpunit/Unit/LanguageTargetLinksCacheTest.php
+++ b/tests/phpunit/Unit/LanguageTargetLinksCacheTest.php
@@ -24,7 +24,7 @@ class LanguageTargetLinksCacheTest extends \PHPUnit_Framework_TestCase {
 	private $cache;
 	private $cacheKeyProvider;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->cache = CacheFactory::getInstance()->newMediaWikiCache( new HashBagOStuff() );

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -20,7 +20,7 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	private $parser;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->parser = new Parser();


### PR DESCRIPTION
This PR addresses or contains:
- Makefile that will run the tests locally using a container (_e.g._ docker) using the `test` target.  To use: `make test`
- Set up CI so that it uses the makefile to drive the tests.  This keeps most of the complexity in one place that can be used on different platforms.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #90 
