### PR TITLE
Replace usages of deprecated wfWikiID()

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This [video](https://vimeo.com/115871518) demonstrates the functionality of the 
 ## Requirements
 
 - PHP 7.1 or later
-- MediaWiki 1.31 or later
+- MediaWiki 1.35 or later
 - [Semantic MediaWiki][smw] 3.0 or later
 
 ## Installation

--- a/SemanticInterlanguageLinks.php
+++ b/SemanticInterlanguageLinks.php
@@ -50,7 +50,7 @@ class SemanticInterlanguageLinks {
 		] );
 
 		$cacheKeyProvider = new CacheKeyProvider(
-			$GLOBALS['wgCachePrefix'] === false ? wfWikiID() : $GLOBALS['wgCachePrefix']
+			$GLOBALS['wgCachePrefix'] === false ? WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix']
 		);
 
 		$hookRegistry = new HookRegistry(

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.31"
+		"MediaWiki": ">= 1.35"
 	},
 	"MessagesDirs": {
 		"SemanticInterlanguageLinks": [


### PR DESCRIPTION
The global function wfWikiID() is hard deprecated since 1.38, and its usages should be replaced with WikiMap::getCurrentWikiId().

This PR addresses or contains:
- https://phabricator.wikimedia.org/T298059

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed