### PR TITLE
MW 1.42 compatibility fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"php": ">=7.1.0",
 		"composer/installers": "1.*,>=1.0.1",
 		"onoi/cache": "~1.2",
-		"mediawiki/semantic-media-wiki": "~3.0|@dev"
+		"mediawiki/semantic-media-wiki": ">=3.0|@dev"
 	},
 	"require-dev": {
 		"mediawiki/semantic-media-wiki": "@dev"

--- a/src/AnnotatedLanguageParserFunction.php
+++ b/src/AnnotatedLanguageParserFunction.php
@@ -2,6 +2,7 @@
 
 namespace SIL;
 
+use MediaWiki\MediaWikiServices;
 use Title;
 use Language;
 
@@ -72,7 +73,7 @@ class AnnotatedLanguageParserFunction {
 
 		$wikitext .= "|target-link=" . $this->modifyTargetLink( $source );
 		$wikitext .= "|lang-code=" . Localizer::asBCP47FormattedLanguageCode( $languageCode );
-		$wikitext .= "|lang-name=" . Language::fetchLanguageName( $languageCode );
+		$wikitext .= "|lang-name=" . MediaWikiServices::getInstance()->getLanguageNameUtils()->getLanguageName( $languageCode );
 
 		$templateText .= '{{' . $template . $wikitext . '}}';
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -100,7 +100,7 @@ class HookRegistry {
 		$interlanguageLinksLookup->setStore( $store );
 
 		/**
-		 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks.md
+		 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.property.initproperties.md
 		 */
 		$this->handlers['SMW::Property::initProperties'] = function ( $baseRegistry ) {
 
@@ -165,7 +165,7 @@ class HookRegistry {
 		};
 
 		/**
-		 * https://www.mediawiki.org/wiki/Manual:Hooks/ArticleDelete
+		 * https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.sqlstore.beforedeletesubjectcomplete.md
 		 */
 		$this->handlers['SMW::SQLStore::BeforeDeleteSubjectComplete'] = function ( $store, $title ) use ( $interlanguageLinksLookup ) {
 
@@ -176,7 +176,7 @@ class HookRegistry {
 		};
 
 		/**
-		 * https://www.mediawiki.org/wiki/Manual:Hooks/TitleMoveComplete
+		 * https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.sqlstore.beforechangetitlecomplete.md
 		 */
 		$this->handlers['SMW::SQLStore::BeforeChangeTitleComplete'] = function ( $store, $oldTitle, $newTitle, $pageid, $redirid ) use ( $interlanguageLinksLookup ) {
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -233,7 +233,8 @@ class HookRegistry {
 		 */
 		$this->handlers['PageContentLanguage'] = function ( $title, &$pageLang ) use ( $pageContentLanguageOnTheFlyModifier ) {
 
-			$pageLang = MediaWikiServices::getInstance()->getLanguageFactory()->getLanguage( $pageContentLanguageOnTheFlyModifier->getPageContentLanguage(
+			$langFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+			$pageLang = $langFactory->getLanguage( $pageContentLanguageOnTheFlyModifier->getPageContentLanguage(
 				$title,
 				$pageLang
 			) );

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -233,11 +233,11 @@ class HookRegistry {
 		 */
 		$this->handlers['PageContentLanguage'] = function ( $title, &$pageLang ) use ( $pageContentLanguageOnTheFlyModifier ) {
 
-			$langFactory = MediaWikiServices::getInstance()->getLanguageFactory();
-			$pageLang = $langFactory->getLanguage( $pageContentLanguageOnTheFlyModifier->getPageContentLanguage(
+			$contentLang = $pageContentLanguageOnTheFlyModifier->getPageContentLanguage(
 				$title,
 				$pageLang
-			) );
+			);
+			$pageLang = MediaWikiServices::getInstance()->getLanguageFactory()->getLanguage( $contentLang );
 
 			return true;
 		};

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -2,6 +2,7 @@
 
 namespace SIL;
 
+use MediaWiki\MediaWikiServices;
 use Onoi\Cache\Cache;
 use SMW\Store;
 use SMW\ApplicationFactory;
@@ -9,7 +10,6 @@ use SMW\InMemoryPoolCache;
 use SIL\Search\SearchResultModifier;
 use SIL\Search\LanguageResultMatchFinder;
 use SIL\Category\LanguageFilterCategoryPage;
-use Hooks;
 use Language;
 
 /**
@@ -44,7 +44,7 @@ class HookRegistry {
 	 * @return boolean
 	 */
 	public function isRegistered( $name ) {
-		return Hooks::isRegistered( $name );
+		return MediaWikiServices::getInstance()->getHookContainer()->isRegistered( $name );
 	}
 
 	/**
@@ -62,8 +62,9 @@ class HookRegistry {
 	 * @since  1.0
 	 */
 	public function register() {
+		$hooks = MediaWikiServices::getInstance()->getHookContainer();
 		foreach ( $this->handlers as $name => $callback ) {
-			Hooks::register( $name, $callback );
+			$hooks->register( $name, $callback );
 		}
 	}
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -231,11 +231,9 @@ class HookRegistry {
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/PageContentLanguage
 		 */
-		$this->handlers['PageContentLanguage'] = function ( $title, Language &$pageLang ) use ( $pageContentLanguageOnTheFlyModifier ) {
+		$this->handlers['PageContentLanguage'] = function ( $title, &$pageLang ) use ( $pageContentLanguageOnTheFlyModifier ) {
 
-		    // PageContentLanguage now requires pageLang of type Language
-			// https://phabricator.wikimedia.org/T214358
-			$pageLang = Language::factory( $pageContentLanguageOnTheFlyModifier->getPageContentLanguage(
+			$pageLang = MediaWikiServices::getInstance()->getLanguageFactory()->getLanguage( $pageContentLanguageOnTheFlyModifier->getPageContentLanguage(
 				$title,
 				$pageLang
 			) );

--- a/src/InterlanguageLink.php
+++ b/src/InterlanguageLink.php
@@ -34,7 +34,7 @@ class InterlanguageLink {
 	 * @param string|null $languageCode
 	 * @param Title|string $linkReference
 	 */
-	public function __construct( $languageCode = null, $linkReference ) {
+	public function __construct( $languageCode = null, $linkReference = null ) {
 		$this->languageCode = $languageCode;
 		$this->linkReference = $linkReference instanceOf Title ? $linkReference : Title::newFromText( $linkReference );
 	}

--- a/src/InterlanguageLinkParserFunction.php
+++ b/src/InterlanguageLinkParserFunction.php
@@ -3,6 +3,7 @@
 namespace SIL;
 
 use Onoi\Cache\CacheFactory;
+use MediaWiki\MediaWikiServices;
 use Title;
 use Language;
 
@@ -181,7 +182,7 @@ class InterlanguageLinkParserFunction {
 			return false;
 		}
 
-		return Language::isSupportedLanguage( $languageCode );
+		return MediaWikiServices::getInstance()->getLanguageNameUtils()->isSupportedLanguage( $languageCode );
 	}
 
 	private function createErrorMessageFor( $messageKey, $arg1 = '', $arg2 = '', $arg3 = '',$arg4 = '' ) {

--- a/src/InterlanguageListParserFunction.php
+++ b/src/InterlanguageListParserFunction.php
@@ -2,6 +2,7 @@
 
 namespace SIL;
 
+use MediaWiki\MediaWikiServices;
 use Title;
 use Language;
 
@@ -86,6 +87,7 @@ class InterlanguageListParserFunction {
 		$result = '';
 		$templateText = '';
 		$i = 0;
+		$langUtils = MediaWikiServices::getInstance()->getLanguageNameUtils();
 
 		foreach ( $languageTargetLinks as $languageCode => $targetLink ) {
 
@@ -94,7 +96,7 @@ class InterlanguageListParserFunction {
 			$wikitext .= "|#=" . $i++;
 			$wikitext .= "|target-link=" . $this->modifyTargetLink( $targetLink );
 			$wikitext .= "|lang-code=" . Localizer::asBCP47FormattedLanguageCode( $languageCode );
-			$wikitext .= "|lang-name=" . Language::fetchLanguageName( $languageCode );
+			$wikitext .= "|lang-name=" . $langUtils->getLanguageName( $languageCode );
 
 			$templateText .= '{{' . $template . $wikitext . '}}';
 		}

--- a/src/PageContentLanguageOnTheFlyModifier.php
+++ b/src/PageContentLanguageOnTheFlyModifier.php
@@ -66,7 +66,7 @@ class PageContentLanguageOnTheFlyModifier {
 		$hash = $this->getHashFrom( $title );
 
 		// Convert language codes from BCP 47 to lowercase to ensure that codes
-		// are matchable against `Language::fetchLanguageNames` for languages like
+		// are matchable against `LanguageNameUtils->getLanguageNames` for languages like
 		// zh-Hans etc.
 		if ( ( $cachedLanguageCode = $this->intermediaryCache->fetch( $hash ) ) ) {
 			return strtolower( $cachedLanguageCode );

--- a/src/Search/SearchResultModifier.php
+++ b/src/Search/SearchResultModifier.php
@@ -116,7 +116,7 @@ class SearchResultModifier {
 	 */
 	public function createHtmlLanguageFilterSelector( $defaultLanguagefilter ) {
 
-		$languages = Language::fetchLanguageNames();
+		$languages = MediaWikiServices::getInstance()->getLanguageNameUtils()->getLanguageNames();
 
 		ksort( $languages );
 

--- a/src/SiteLanguageLinkModifier.php
+++ b/src/SiteLanguageLinkModifier.php
@@ -2,6 +2,7 @@
 
 namespace SIL;
 
+use MediaWiki\MediaWikiServices;
 use Title;
 use Language;
 
@@ -53,7 +54,7 @@ class SiteLanguageLinkModifier {
 			return false;
 		}
 
-		$languageName = Language::fetchLanguageName( $languageCode );
+		$languageName = MediaWikiServices::getInstance()->getLanguageNameUtils()->getLanguageName( $languageCode );
 
 		$languageLink = [
 			'href'  => Title::newFromText( $target )->getFullURL(),

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -3,6 +3,7 @@
 namespace SIL\Tests;
 
 use Language;
+use MediaWiki\MediaWikiServices;
 use SIL\HookRegistry;
 use SMW\Tests\PHPUnitCompat;
 use Title;
@@ -187,7 +188,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 	public function doTestPageContentLanguage( $instance ) {
 
 		$handler = 'PageContentLanguage';
-		$pageLang = Language::factory( 'en' );
+		$pageLang = MediaWikiServices::getInstance()->getLanguageFactory()->getLanguage( 'en' );
 
 		$title = Title::newFromText( __METHOD__ );
 


### PR DESCRIPTION
Fixes deprecated messages and errors caused by removed classes, fixing issue #95, #97, #98, #99. 