### PR TITLE
Replace DB_MASTER with DB_PRIMARY

### DIFF
--- a/src/PageContentLanguageDbModifier.php
+++ b/src/PageContentLanguageDbModifier.php
@@ -114,7 +114,7 @@ class PageContentLanguageDbModifier {
 		$title = $this->title;
 
 		if ( $connection === null ) {
-			 $connection = wfGetDB( DB_MASTER );
+			 $connection = wfGetDB( DB_PRIMARY );
 		}
 
 		$connection->onTransactionCommitOrIdle( function() use ( $connection, $expectedLanguageCode, $dbPageLanguage, $title ) {


### PR DESCRIPTION
DB_MASTER was deprecated in MediaWiki 1.36 and removed in MediaWiki 1.43

See https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5634#issuecomment-2333836086
