### PR TITLE
Replace use of deprecated BaseSearchResultSet::next()

### DIFF
--- a/src/Search/LanguageResultMatchFinder.php
+++ b/src/Search/LanguageResultMatchFinder.php
@@ -38,7 +38,9 @@ class LanguageResultMatchFinder {
 	public function matchResultsToLanguage( SearchResultSet $matches, $languageCode ) {
 		$mappedMatches = [];
 
-		while ( $searchresult = $matches->next() ) {
+		$matches = $matches->extractResults();
+
+		foreach ( $matches as $searchresult ) {
 
 			$title = $searchresult->getTitle();
 


### PR DESCRIPTION
Replaces a function deprecated in core since 1.32
