### PR TITLE
Remove the deprecated egSIL settings

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,6 +15,9 @@ Not yet released.
 * Migrated the extension registration fully into `extension.json` (settings, messages, magic
   words and hooks are now declared declaratively), removing the legacy `DefaultSettings.php` and
   the `SemanticInterlanguageLinks.php` entry point
+* Removed support for the long-deprecated `$egSILCacheType` and
+  `$egSILEnabledCategoryFilterByLanguage` settings; use `$silgCacheType` and
+  `$silgEnabledCategoryFilterByLanguage` instead
 
 ### 2.1.0
 

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -19,15 +19,6 @@ class Setup {
 	 * @since 1.3
 	 */
 	public static function onExtensionFunction() {
-		// Legacy
-		if ( isset( $GLOBALS['egSILEnabledCategoryFilterByLanguage'] ) ) {
-			$GLOBALS['silgEnabledCategoryFilterByLanguage'] = $GLOBALS['egSILEnabledCategoryFilterByLanguage'];
-		}
-
-		if ( isset( $GLOBALS['egSILCacheType'] ) ) {
-			$GLOBALS['silgCacheType'] = $GLOBALS['egSILCacheType'];
-		}
-
 		$cacheFactory = new CacheFactory();
 
 		$compositeCache = $cacheFactory->newCompositeCache( [


### PR DESCRIPTION
## Summary

Drops the back-compat shim that forwarded the long-deprecated `$egSILCacheType` and `$egSILEnabledCategoryFilterByLanguage` globals to their current `$silgCacheType` and `$silgEnabledCategoryFilterByLanguage` equivalents.

These `eg`-prefixed names were an undocumented legacy alias (only the `silg` names were ever documented). With registration now declarative, `$silgCacheType` and `$silgEnabledCategoryFilterByLanguage` are provided as `extension.json` `config` defaults and remain overridable from `LocalSettings.php` using the `silg` names — so the shim no longer carries its weight. This is a breaking change for any setup still using the `egSIL` names, shipped in the unreleased 3.0.0 major and noted in the release notes.

## Verification

Against a live MediaWiki 1.43 / Semantic MediaWiki 7.0 container:

- `composer analyze` clean (parallel-lint + PHPCS + minus-x) — the removal leaves no unused imports.
- `composer phpunit` green: 219 tests, 412 assertions, 0 failures/errors.
- Live check: `$silgCacheType` (-1) and `$silgEnabledCategoryFilterByLanguage` (true) still populate from the `config` defaults without the shim; `isset($egSILCacheType)` is now false; the extension function still registers its runtime hooks.
- Live render of `{{interlanguagelink:la|Lorem ipsum}}` + `{{annotatedlanguage:}}` unchanged.