### PR TITLE
Use MediaWiki's native object cache instead of onoi/cache

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,8 @@ Not yet released.
 * Removed support for the long-deprecated `$egSILCacheType` and
   `$egSILEnabledCategoryFilterByLanguage` settings; use `$silgCacheType` and
   `$silgEnabledCategoryFilterByLanguage` instead
+* Replaced the `onoi/cache` dependency with MediaWiki's native object cache
+  (`BagOStuff`), removing the extension's last third-party runtime dependency
 
 ### 2.1.0
 

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
 	},
 	"require": {
 		"php": ">=8.1.0",
-		"composer/installers": ">=1.0.1",
-		"onoi/cache": "~1.2"
+		"composer/installers": ">=1.0.1"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "46.0.0",

--- a/extension.json
+++ b/extension.json
@@ -47,6 +47,5 @@
 			"description": "Enable language filtering on the category page."
 		}
 	},
-	"load_composer_autoloader": true,
 	"manifest_version": 2
 }

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -3,11 +3,11 @@
 namespace SIL;
 
 use MediaWiki\MediaWikiServices;
-use Onoi\Cache\Cache;
-use Onoi\Cache\CacheFactory;
 use SIL\Category\LanguageFilterCategoryPage;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
+use Wikimedia\ObjectCache\HashBagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -26,10 +26,10 @@ class HookRegistry {
 	 * @since 1.0
 	 *
 	 * @param Store $store
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 * @param CacheKeyProvider $cacheKeyProvider
 	 */
-	public function __construct( Store $store, Cache $cache, CacheKeyProvider $cacheKeyProvider ) {
+	public function __construct( Store $store, BagOStuff $cache, CacheKeyProvider $cacheKeyProvider ) {
 		$this->addCallbackHandlers( $store, $cache, $cacheKeyProvider );
 	}
 
@@ -122,11 +122,9 @@ class HookRegistry {
 	}
 
 	private function registerInterlanguageParserHooks( InterlanguageLinksLookup $interlanguageLinksLookup ) {
-		$cacheFactory = new CacheFactory();
-
 		$pageContentLanguageOnTheFlyModifier = new PageContentLanguageOnTheFlyModifier(
 			$interlanguageLinksLookup,
-			$cacheFactory->newFixedInMemoryLruCache( 500 )
+			new HashBagOStuff( [ 'maxKeys' => 500 ] )
 		);
 
 		/**

--- a/src/LanguageTargetLinksCache.php
+++ b/src/LanguageTargetLinksCache.php
@@ -3,8 +3,8 @@
 namespace SIL;
 
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use SMW\DataItems\WikiPage;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * To make a page view responsive and avoid a repetitive or exhausting query
@@ -23,7 +23,7 @@ use SMW\DataItems\WikiPage;
 class LanguageTargetLinksCache {
 
 	/**
-	 * @var Cache
+	 * @var BagOStuff
 	 */
 	private $cache;
 
@@ -49,10 +49,10 @@ class LanguageTargetLinksCache {
 	/**
 	 * @since 1.0
 	 *
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 * @param CacheKeyProvider $cacheKeyProvider
 	 */
-	public function __construct( Cache $cache, CacheKeyProvider $cacheKeyProvider ) {
+	public function __construct( BagOStuff $cache, CacheKeyProvider $cacheKeyProvider ) {
 		$this->cache = $cache;
 		$this->cacheKeyProvider = $cacheKeyProvider;
 	}
@@ -104,7 +104,7 @@ class LanguageTargetLinksCache {
 			return false;
 		}
 
-		$cachedLanguageTargetLinks = $this->cache->fetch(
+		$cachedLanguageTargetLinks = $this->cache->get(
 			$this->cacheKeyProvider->getSiteCacheKey( $interlanguageLink->getLinkReference()->getPrefixedText() )
 		);
 
@@ -141,7 +141,7 @@ class LanguageTargetLinksCache {
 			return;
 		}
 
-		$this->cache->save(
+		$this->cache->set(
 			$this->cacheKeyProvider->getSiteCacheKey( $interlanguageLink->getLinkReference()->getPrefixedText() ),
 			$normalizedLanguageTargetLinks
 		);
@@ -165,7 +165,7 @@ class LanguageTargetLinksCache {
 				$linkReference->getTitle()->getPrefixedText()
 			);
 
-			$cachedLanguageTargetLinks = $this->cache->fetch( $siteCacheKey );
+			$cachedLanguageTargetLinks = $this->cache->get( $siteCacheKey );
 
 			if ( !is_array( $cachedLanguageTargetLinks ) ) {
 				continue;
@@ -197,7 +197,7 @@ class LanguageTargetLinksCache {
 		);
 
 		if ( $this->pageLanguageCacheStrategy !== 'blob' ) {
-			return $this->cache->fetch( $pageCacheKey );
+			return $this->cache->get( $pageCacheKey );
 		}
 
 		$pageLanguageCacheBlob = $this->getPageLanguageCacheBlob();
@@ -209,7 +209,7 @@ class LanguageTargetLinksCache {
 		if ( $this->pageLanguageCacheStrategy !== 'blob' ) {
 
 			foreach ( $normalizedLanguageTargetLinks as $languageCode => $target ) {
-				$this->cache->save(
+				$this->cache->set(
 					$this->cacheKeyProvider->getPageCacheKey( $target, false ),
 					$languageCode
 				);
@@ -224,7 +224,7 @@ class LanguageTargetLinksCache {
 			$pageLanguageCacheBlob[ $this->cacheKeyProvider->getPageCacheKey( $target, true ) ] = $languageCode;
 		}
 
-		$this->cache->save(
+		$this->cache->set(
 			$this->cacheKeyProvider->getPageLanguageCacheBlobKey(),
 			$pageLanguageCacheBlob
 		);
@@ -244,14 +244,14 @@ class LanguageTargetLinksCache {
 		$pageLanguageCacheBlob = $this->getPageLanguageCacheBlob();
 		unset( $pageLanguageCacheBlob[ $this->cacheKeyProvider->getPageCacheKey( $title->getPrefixedText(), true ) ] );
 
-		$this->cache->save(
+		$this->cache->set(
 			$this->cacheKeyProvider->getPageLanguageCacheBlobKey(),
 			$pageLanguageCacheBlob
 		);
 	}
 
 	private function getPageLanguageCacheBlob() {
-		$pageLanguageCacheBlob = $this->cache->fetch(
+		$pageLanguageCacheBlob = $this->cache->get(
 			$this->cacheKeyProvider->getPageLanguageCacheBlobKey()
 		);
 

--- a/src/PageContentLanguageOnTheFlyModifier.php
+++ b/src/PageContentLanguageOnTheFlyModifier.php
@@ -3,7 +3,7 @@
 namespace SIL;
 
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * Modifies the content language based on the SIL annotation found
@@ -22,7 +22,7 @@ class PageContentLanguageOnTheFlyModifier {
 	private $interlanguageLinksLookup;
 
 	/**
-	 * @var Cache
+	 * @var BagOStuff
 	 */
 	private $intermediaryCache;
 
@@ -30,9 +30,9 @@ class PageContentLanguageOnTheFlyModifier {
 	 * @since 1.0
 	 *
 	 * @param InterlanguageLinksLookup $interlanguageLinksLookup
-	 * @param Cache $intermediaryCache
+	 * @param BagOStuff $intermediaryCache
 	 */
-	public function __construct( InterlanguageLinksLookup $interlanguageLinksLookup, Cache $intermediaryCache ) {
+	public function __construct( InterlanguageLinksLookup $interlanguageLinksLookup, BagOStuff $intermediaryCache ) {
 		$this->interlanguageLinksLookup = $interlanguageLinksLookup;
 		$this->intermediaryCache = $intermediaryCache;
 	}
@@ -44,7 +44,7 @@ class PageContentLanguageOnTheFlyModifier {
 	 * @param string $languageCode
 	 */
 	public function addToIntermediaryCache( Title $title, $languageCode ) {
-		$this->intermediaryCache->save( $this->getHashFrom( $title ), $languageCode );
+		$this->intermediaryCache->set( $this->getHashFrom( $title ), $languageCode );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class PageContentLanguageOnTheFlyModifier {
 		// Convert language codes from BCP 47 to lowercase to ensure that codes
 		// are matchable against `LanguageNameUtils->getLanguageNames` for languages like
 		// zh-Hans etc.
-		if ( ( $cachedLanguageCode = $this->intermediaryCache->fetch( $hash ) ) ) {
+		if ( ( $cachedLanguageCode = $this->intermediaryCache->get( $hash ) ) ) {
 			return strtolower( $cachedLanguageCode );
 		}
 
@@ -77,7 +77,7 @@ class PageContentLanguageOnTheFlyModifier {
 
 		$pageLanguage = strtolower( $pageLanguage );
 
-		$this->intermediaryCache->save( $hash, $pageLanguage );
+		$this->intermediaryCache->set( $hash, $pageLanguage );
 
 		return $pageLanguage;
 	}

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -2,10 +2,10 @@
 
 namespace SIL;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\WikiMap\WikiMap;
-use ObjectCache;
-use Onoi\Cache\CacheFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use Wikimedia\ObjectCache\CachedBagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -19,12 +19,14 @@ class Setup {
 	 * @since 1.3
 	 */
 	public static function onExtensionFunction() {
-		$cacheFactory = new CacheFactory();
+		$objectCacheFactory = MediaWikiServices::getInstance()->getObjectCacheFactory();
 
-		$compositeCache = $cacheFactory->newCompositeCache( [
-			$cacheFactory->newFixedInMemoryLruCache( 500 ),
-			$cacheFactory->newMediaWikiCache( ObjectCache::getInstance( $GLOBALS['silgCacheType'] ) )
-		] );
+		// A process-local cache tier (bounded to 500 entries) over the
+		// configured persistent object cache, mirroring the previous composite.
+		$cache = new CachedBagOStuff(
+			$objectCacheFactory->getInstance( $GLOBALS['silgCacheType'] ),
+			[ 'maxKeys' => 500 ]
+		);
 
 		$cacheKeyProvider = new CacheKeyProvider(
 			$GLOBALS['wgCachePrefix'] === false ? WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix']
@@ -32,7 +34,7 @@ class Setup {
 
 		$hookRegistry = new HookRegistry(
 			ApplicationFactory::getInstance()->getStore(),
-			$compositeCache,
+			$cache,
 			$cacheKeyProvider
 		);
 

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -5,6 +5,7 @@ namespace SIL\Tests;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SIL\HookRegistry;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SIL\HookRegistry
@@ -28,7 +29,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 

--- a/tests/phpunit/Unit/LanguageTargetLinksCacheTest.php
+++ b/tests/phpunit/Unit/LanguageTargetLinksCacheTest.php
@@ -2,14 +2,14 @@
 
 namespace SIL\Tests;
 
-use HashBagOStuff;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
-use Onoi\Cache\CacheFactory;
 use SIL\CacheKeyProvider;
 use SIL\InterlanguageLink;
 use SIL\LanguageTargetLinksCache;
 use SMW\DataItems\WikiPage;
+use Wikimedia\ObjectCache\BagOStuff;
+use Wikimedia\ObjectCache\HashBagOStuff;
 
 /**
  * @covers \SIL\LanguageTargetLinksCache
@@ -28,12 +28,12 @@ class LanguageTargetLinksCacheTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->cache = CacheFactory::getInstance()->newMediaWikiCache( new HashBagOStuff() );
+		$this->cache = new HashBagOStuff();
 		$this->cacheKeyProvider = new CacheKeyProvider( 'foo' );
 	}
 
 	public function testCanConstruct() {
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -298,12 +298,12 @@ class LanguageTargetLinksCacheTest extends \PHPUnit\Framework\TestCase {
 
 		$title = Title::newFromText( 'Bar', NS_MAIN );
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
 		$cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->stringContains( $id ),
 				$data );

--- a/tests/phpunit/Unit/PageContentLanguageOnTheFlyModifierTest.php
+++ b/tests/phpunit/Unit/PageContentLanguageOnTheFlyModifierTest.php
@@ -4,6 +4,7 @@ namespace SIL\Tests;
 
 use MediaWiki\Title\Title;
 use SIL\PageContentLanguageOnTheFlyModifier;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SIL\PageContentLanguageOnTheFlyModifier
@@ -21,7 +22,7 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit\Framework\TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -38,7 +39,7 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit\Framework\TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -68,12 +69,12 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit\Framework\TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( 'zh-Hans' );
 
 		$interlanguageLinksLookup = $this->getMockBuilder( '\SIL\InterlanguageLinksLookup' )
@@ -99,7 +100,7 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit\Framework\TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -136,7 +137,7 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit\Framework\TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -167,12 +168,12 @@ class PageContentLanguageOnTheFlyModifierTest extends \PHPUnit\Framework\TestCas
 			->method( 'getPrefixedText' )
 			->willReturn( 'Foo' );
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->anything(),
 				'BAR' );


### PR DESCRIPTION
## Summary

Removes the `onoi/cache` dependency in favour of MediaWiki's native object cache, eliminating the extension's last third-party runtime dependency. Behaviour is preserved: the same `$silgCacheType` setting (default `CACHE_ANYTHING`), the same indefinite cache lifetime, and the same process-local cache tier.

This is the first of two PRs; a follow-up will move the remaining procedural registration (`Setup.php`) to declarative `HookHandlers` + service wiring.

## Changes

- `LanguageTargetLinksCache` and `PageContentLanguageOnTheFlyModifier` now type-hint `Wikimedia\ObjectCache\BagOStuff` and use its `get()`/`set()`/`delete()` API (the onoi `fetch`/`save` calls renamed). Values are stored with no expiry, preserving the previous indefinite TTL.
- `Setup` builds a `CachedBagOStuff` bounded to 500 entries over the object cache from `ObjectCacheFactory->getInstance( $silgCacheType )`. This preserves the process-local-LRU-over-persistent tiering the previous onoi composite provided, and replaces the deprecated `ObjectCache::getInstance()`.
- The per-request intermediary cache becomes `HashBagOStuff( [ 'maxKeys' => 500 ] )`.
- `onoi/cache` removed from `composer.json`; `load_composer_autoloader` removed from `extension.json` (no third-party runtime dependency remains).

`onoi/cache` was the only third-party runtime `require`, and Semantic MediaWiki 7.0 itself no longer ships it, so it is genuinely removed from a real install.

## Verification

Against a live MediaWiki 1.43 / Semantic MediaWiki 7.0 container:

- `composer analyze` clean (parallel-lint + PHPCS + minus-x).
- `composer phpunit` green: 219 tests, 412 assertions, 0 failures/errors — including a run with `vendor/onoi` physically deleted, confirming nothing loads it. (`phpunit.xml.dist` converts warnings/notices to exceptions, so a `BagOStuff` key-validation warning would have failed the suite.)
- Live render: a fresh interlanguage reference renders its annotation cleanly; a duplicate reference produces the correct "already exists for page X" conflict notice — exercising the persistent cache layer and the cross-page lookup through the new `BagOStuff`.